### PR TITLE
fix: カメラ角度ズレを修正

### DIFF
--- a/src/rendering/CameraFollowController.ts
+++ b/src/rendering/CameraFollowController.ts
@@ -34,19 +34,14 @@ export class CameraFollowController {
     }
 
     const controls = this.sceneManager.getControls();
-    const camera   = this.sceneManager.getCamera();
     const target   = controls.target;
-
-    const offsetX = camera.position.x - target.x;
-    const offsetY = camera.position.y - target.y;
-    const offsetZ = camera.position.z - target.z;
 
     const tl = gsap.timeline({ onComplete: () => { this.followTween = null; } });
     tl.to(target, { x, y, duration, ease }, 0);
-    tl.to(camera.position, {
-      x: x + offsetX,
-      y: y + offsetY,
-      z: offsetZ + target.z,
+    tl.to(this.sceneManager.getCamera().position, {
+      x: x + CameraConfig.OffsetX,
+      y: y + CameraConfig.OffsetY,
+      z: CameraConfig.OffsetZ,
       duration,
       ease,
     }, 0);


### PR DESCRIPTION
Closes #14

## 概要
プレイヤー選択変更時にカメラ角度がおかしくなるバグを修正。

## 原因
`panTo()` が現在のカメラ位置とターゲットの差分からオフセットを動的計算していたため、カメラ角度がズレた状態で呼ばれるとそのズレを引き継いでいた。

## 修正
`snapTo()` と同様に `CameraConfig.OffsetX/Y/Z` の固定値を使用するよう変更。