### PR TITLE
feat: 視界外の敵を非表示にするフォグ・オブ・ウォー機能

### DIFF
--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -36,6 +36,9 @@ export const PlayerConfig = {
 
   /** Maximum number of grid steps a player can move per turn */
   MoveRange: 3,
+
+  /** 視界外の敵を非表示にするか */
+  FogOfWarEnabled: true,
 } as const;
 
 /**

--- a/src/rendering/PlayerLifecycleManager.ts
+++ b/src/rendering/PlayerLifecycleManager.ts
@@ -61,6 +61,12 @@ export class PlayerLifecycleManager {
     }, 300);
   }
 
+  setVisible(playerId: string, visible: boolean): void {
+    const obj = this.playerMeshes.get(playerId);
+    if (!obj) return;
+    obj.visible = visible;
+  }
+
   hidePlayer(playerId: string): void {
     const obj = this.playerMeshes.get(playerId);
     if (!obj) return;

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { Model } from '../model/model';
 import { ViewAngleVisualizer } from './ViewAngleVisualizer';
 import { SceneManager } from './SceneManager';
-import { CameraConfig } from '../config/GameConfig';
+import { CameraConfig, PlayerConfig } from '../config/GameConfig';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
 import { PlayerAnimator } from './PlayerAnimator';
 import { PlayerLifecycleManager } from './PlayerLifecycleManager';
@@ -89,12 +89,31 @@ export class VisualizationSync {
   }
 
   private updatePlayers(): void {
+    const activePlayer = this.model.getPlayer(this.activePlayerId);
+
+    const visibleNodeIds = new Set<number>();
+    if (PlayerConfig.FogOfWarEnabled && activePlayer) {
+      const nodes = this.model.getVisibleNodesAtAngle(
+        activePlayer.node, activePlayer.angle, PlayerConfig.MaxViewDistance,
+      );
+      for (const n of nodes) visibleNodeIds.add(n.id);
+      visibleNodeIds.add(activePlayer.node.id);
+    }
+
     for (const [playerId, player] of this.model.players) {
+      if (!player.isAlive) continue;
+
       const isActive = playerId === this.activePlayerId;
+      const shouldShow = !PlayerConfig.FogOfWarEnabled
+        || isActive
+        || visibleNodeIds.has(player.node.id);
+
+      this.lifecycle.setVisible(playerId, shouldShow);
+      if (!shouldShow) continue;
+
       const moving = this.lifecycle.applyTransform(
         playerId, player.node.x, player.node.y, player.angle, isActive,
       );
-
       if (isActive && moving) {
         this.camera.panTo(player.node.x, player.node.y, CameraConfig.FollowMoveDuration, CameraConfig.FollowMoveEase);
       }


### PR DESCRIPTION
Closes #13

## 概要
プレイヤーの視野角内に入った敵のみ表示するフォグ・オブ・ウォー機能を実装。

## 変更内容
- `GameConfig.ts`: `PlayerConfig.FogOfWarEnabled` フラグを追加
- `PlayerLifecycleManager.ts`: `setVisible()` メソッドを追加（アニメーションなし即時切り替え）
- `VisualizationSync.ts`: `updatePlayers()` で視界ノードセットを構築し、視界外の敵メッシュを非表示に制御

## 既存動作への影響なし
- `hidePlayer()` は死亡演出専用のまま変更なし
- `FogOfWarEnabled: false` にすれば従来通り全員表示