### PR TITLE
feat: TPS風カメラ実装 (#19)

### DIFF
--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -214,8 +214,17 @@ export const AnimationConfig = {
  * Camera configuration
  */
 export const CameraConfig = {
-  /** Field of view angle */
+  /** Field of view angle (default) */
   FOV: 90,
+
+  /** FOV minimum (most zoomed in) */
+  FOVMin: 20,
+
+  /** FOV maximum (most zoomed out) */
+  FOVMax: 120,
+
+  /** FOV change per wheel tick */
+  FOVWheelStep: 5,
 
   /** Camera initial Z position */
   InitialZPosition: 10,
@@ -229,14 +238,11 @@ export const CameraConfig = {
   /** Enable rotation control */
   EnableRotate: false,
 
-  /** 3D斜め視点: カメラの target に対する X オフセット（横ずれ、0=真後ろ） */
-  OffsetX: 0,
+  /** TPS後方追従: プレイヤー後方のXY距離（プレイヤーの向きの逆方向へ配置） */
+  BackDistance: 60,
 
-  /** 3D斜め視点: カメラの target に対する Y オフセット（手前引き）。負値でプレイヤー後方から */
-  OffsetY: -150,
-
-  /** 3D斜め視点: カメラの Z オフセット（高さ）。大きいほど俯瞰 */
-  OffsetZ: 150,
+  /** TPS後方追従: カメラの Z オフセット（高さ）。小さいほどFPS寄り */
+  OffsetZ: 60,
 
   /** パン操作を無効化（カメラは自動追従） */
   EnablePan: false,

--- a/src/rendering/CameraFollowController.ts
+++ b/src/rendering/CameraFollowController.ts
@@ -6,46 +6,51 @@ import type { SceneManager } from './SceneManager';
  * Manages camera follow behaviour: smooth pan animations and instant snap.
  */
 export class CameraFollowController {
-  private followTween: gsap.core.Tween | null = null;
+  private followTimeline: gsap.core.Timeline | null = null;
 
   constructor(private sceneManager: SceneManager) {}
 
-  /** Immediately position the camera over (x, y) with no animation. */
-  snapTo(x: number, y: number): void {
-    const controls = this.sceneManager.getControls();
-    const camera   = this.sceneManager.getCamera();
-    controls.target.set(x, y, 0);
-    camera.position.set(
-      x + CameraConfig.OffsetX,
-      y + CameraConfig.OffsetY,
-      CameraConfig.OffsetZ,
-    );
-    controls.update();
+  /** Compute XY camera offset from player angle (degrees) so camera sits behind the player. */
+  private calcOffset(angle: number): { ox: number; oy: number } {
+    const rad = angle * Math.PI / 180;
+    return {
+      ox: -Math.cos(rad) * CameraConfig.BackDistance,
+      oy: -Math.sin(rad) * CameraConfig.BackDistance,
+    };
+  }
+
+  /** Immediately position the camera behind (x, y) facing angle, with no animation. */
+  snapTo(x: number, y: number, angle: number): void {
+    const camera = this.sceneManager.getCamera();
+    const { ox, oy } = this.calcOffset(angle);
+    camera.up.set(0, 0, 1);
+    camera.position.set(x + ox, y + oy, CameraConfig.OffsetZ);
+    camera.lookAt(x, y, 0);
   }
 
   /**
-   * Smoothly pan the camera to (x, y).
-   * Animates both OrbitControls target and camera.position together
-   * to maintain the 3D oblique angle.
+   * Smoothly pan the camera behind (x, y) facing angle.
+   * Animates camera.position and calls lookAt each frame via onUpdate.
    */
-  panTo(x: number, y: number, duration: number, ease: string): void {
-    if (this.followTween) {
-      this.followTween.kill();
+  panTo(x: number, y: number, angle: number, duration: number, ease: string): void {
+    if (this.followTimeline) {
+      this.followTimeline.kill();
     }
 
-    const controls = this.sceneManager.getControls();
-    const target   = controls.target;
+    const camera = this.sceneManager.getCamera();
+    camera.up.set(0, 0, 1);
+    const { ox, oy } = this.calcOffset(angle);
 
-    const tl = gsap.timeline({ onComplete: () => { this.followTween = null; } });
-    tl.to(target, { x, y, duration, ease }, 0);
-    tl.to(this.sceneManager.getCamera().position, {
-      x: x + CameraConfig.OffsetX,
-      y: y + CameraConfig.OffsetY,
+    const tl = gsap.timeline({ onComplete: () => { this.followTimeline = null; } });
+    tl.to(camera.position, {
+      x: x + ox,
+      y: y + oy,
       z: CameraConfig.OffsetZ,
       duration,
       ease,
+      onUpdate: () => camera.lookAt(x, y, 0),
     }, 0);
 
-    this.followTween = tl.getChildren()[0] as gsap.core.Tween;
+    this.followTimeline = tl;
   }
 }

--- a/src/rendering/SceneManager.ts
+++ b/src/rendering/SceneManager.ts
@@ -14,6 +14,7 @@ export class SceneManager {
   private orbitControls: OrbitControls;
   private composer: EffectComposer | null = null;
   private boundHandleResize: () => void;
+  private boundHandleWheel: (e: WheelEvent) => void;
 
   constructor(canvas: HTMLCanvasElement) {
     // Setup renderer
@@ -34,8 +35,8 @@ export class SceneManager {
     this.camera = new THREE.PerspectiveCamera(CameraConfig.FOV, 1.0);
     this.camera.aspect = width / height;
     this.camera.position.set(
-      CameraConfig.OffsetX,
-      CameraConfig.OffsetY,
+      -CameraConfig.BackDistance,
+      0,
       CameraConfig.OffsetZ,
     );
     this.camera.updateProjectionMatrix();
@@ -47,6 +48,7 @@ export class SceneManager {
     this.orbitControls.maxDistance = CameraConfig.MaxDistance;
     this.orbitControls.enableRotate = CameraConfig.EnableRotate;
     this.orbitControls.enablePan = CameraConfig.EnablePan;
+    this.orbitControls.enableZoom = false;
 
     // Add background grid
     this.createBackgroundGrid();
@@ -71,6 +73,10 @@ export class SceneManager {
     // Handle window resize - store bound function to enable proper cleanup
     this.boundHandleResize = this.handleResize.bind(this);
     window.addEventListener('resize', this.boundHandleResize);
+
+    // Handle wheel zoom via FOV
+    this.boundHandleWheel = this.handleWheel.bind(this);
+    canvas.addEventListener('wheel', this.boundHandleWheel, { passive: false });
   }
 
   /**
@@ -125,6 +131,16 @@ export class SceneManager {
       hLine.userData['isGrid'] = true;
       this.scene.add(hLine);
     }
+  }
+
+  /**
+   * Handles wheel events to zoom via FOV adjustment
+   */
+  private handleWheel(e: WheelEvent): void {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? CameraConfig.FOVWheelStep : -CameraConfig.FOVWheelStep;
+    this.camera.fov = Math.max(CameraConfig.FOVMin, Math.min(CameraConfig.FOVMax, this.camera.fov + delta));
+    this.camera.updateProjectionMatrix();
   }
 
   /**

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -48,7 +48,7 @@ export class VisualizationSync {
     // Snap camera to starting player (no animation)
     const initialPlayer = model.getPlayer(activePlayerId);
     if (initialPlayer) {
-      this.camera.snapTo(initialPlayer.node.x, initialPlayer.node.y);
+      this.camera.snapTo(initialPlayer.node.x, initialPlayer.node.y, initialPlayer.angle);
     }
 
     this.subscribeToEvents(eventBus);
@@ -115,7 +115,7 @@ export class VisualizationSync {
         playerId, player.node.x, player.node.y, player.angle, isActive,
       );
       if (isActive && moving) {
-        this.camera.panTo(player.node.x, player.node.y, CameraConfig.FollowMoveDuration, CameraConfig.FollowMoveEase);
+        this.camera.panTo(player.node.x, player.node.y, player.angle, CameraConfig.FollowMoveDuration, CameraConfig.FollowMoveEase);
       }
     }
   }
@@ -127,7 +127,7 @@ export class VisualizationSync {
       this.activePlayerId = data.playerId;
       const player = this.model.getPlayer(data.playerId);
       if (player) {
-        this.camera.panTo(player.node.x, player.node.y, CameraConfig.FollowPanDuration, CameraConfig.FollowPanEase);
+        this.camera.panTo(player.node.x, player.node.y, player.angle, CameraConfig.FollowPanDuration, CameraConfig.FollowPanEase);
       }
       this.doUpdateView();
     });

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -85,7 +85,6 @@ export class ThreeSetup {
    */
   private startRenderLoop(): void {
     const render = () => {
-      this.sceneManager.updateControls();
       this.sceneManager.render();
       requestAnimationFrame(render);
     };


### PR DESCRIPTION
## Summary
- 固定俯瞰視点からTPS風（プレイヤー真後ろ追従）カメラに変更
- プレイヤーの向き(angle)に基づいて後方オフセットを動的計算し、`camera.lookAt()` で正確な向きを実現
- マウスホイールによるFOVズームを追加、OrbitControlsの誤動作（ズーム・毎フレーム回転）を修正

## Changes
- `CameraFollowController`: `calcOffset(angle)` 追加、`snapTo/panTo` にangle引数追加、`camera.up=(0,0,1)` でロール防止
- `SceneManager`: OrbitControlsのズーム無効化、ホイールイベントでFOV変更
- `VisualizationSync`: `snapTo/panTo` 呼び出し3箇所にplayer.angleを渡す
- `threeSetup`: レンダリングループから `updateControls()` を削除
- `GameConfig`: `BackDistance` / `OffsetZ` / `FOVMin` / `FOVMax` / `FOVWheelStep` を追加

## Test plan
- [x] `npm run dev` でゲームを起動
- [x] プレイヤーが移動するとカメラが真後ろに追従することを確認
- [x] プレイヤー切り替え時にカメラが新プレイヤーの後ろに移動することを確認
- [x] マウスホイールでズームイン・アウトできることを確認
- [x] カメラが回転・ロールしないことを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)