### PR TITLE
fix: サーバーのグリッドサイズ・移動検証をクライアントに合わせる (#29)

### DIFF
--- a/server/src/logic/ServerGameLogic.ts
+++ b/server/src/logic/ServerGameLogic.ts
@@ -3,11 +3,12 @@ import { PlayerState } from '../schema/GameState';
 
 // ---- constants (mirrors src/config/GameConfig.ts) -------------------------
 
-const NODES_IN_GRID_SIZE = 20;
+const NODES_IN_GRID_SIZE = 50; // must match client MapConfig.NodesInGridSize (src/config/GameConfig.ts)
 const NODE_SPACING = 30;
 const MAX_VIEW_DISTANCE = 1000;
 const VIEW_ANGLE_DEG = 60;
 const DAMAGE_PER_SHOT = 34;
+const MOVE_RANGE = 3; // must match client PlayerConfig.MoveRange (src/config/GameConfig.ts)
 
 // ---- minimal node / geometry types ----------------------------------------
 
@@ -84,6 +85,24 @@ export class ServerGameLogic {
     }
 
     return adj;
+  }
+
+  private getReachableNodes(startId: number, maxSteps: number): Set<number> {
+    const visited = new Set<number>([startId]);
+    const reachable = new Set<number>();
+    const queue: Array<{ nodeId: number; dist: number }> = [{ nodeId: startId, dist: 0 }];
+    while (queue.length > 0) {
+      const { nodeId, dist } = queue.shift()!;
+      if (dist >= maxSteps) continue;
+      for (const neighbor of this.adjacency[nodeId] ?? []) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          reachable.add(neighbor);
+          queue.push({ nodeId: neighbor, dist: dist + 1 });
+        }
+      }
+    }
+    return reachable;
   }
 
   // ---- geometry helpers -----------------------------------------------------
@@ -182,12 +201,12 @@ export class ServerGameLogic {
     const toNode = this.nodes[action.moveToNodeId];
     if (!toNode) return null;
 
-    // Validate move: destination must be adjacent (or same node)
-    if (
-      action.moveToNodeId !== actor.nodeId &&
-      !this.adjacency[actor.nodeId].includes(action.moveToNodeId)
-    ) {
-      return null;
+    // Validate move: destination must be reachable within MOVE_RANGE steps
+    if (action.moveToNodeId !== actor.nodeId) {
+      const reachable = this.getReachableNodes(actor.nodeId, MOVE_RANGE);
+      if (!reachable.has(action.moveToNodeId)) {
+        return null;
+      }
     }
 
     actor.nodeId = action.moveToNodeId;


### PR DESCRIPTION
## 変更内容

- `NODES_IN_GRID_SIZE` を 20 → 50 に修正（クライアントの `MapConfig.NodesInGridSize` と一致）
- `MOVE_RANGE = 3` 定数を追加（クライアントの `PlayerConfig.MoveRange` と一致）
- 移動検証を「隣接1ステップのみ」→「BFS 3ステップ到達可能」に変更
- `getReachableNodes()` BFS メソッドを追加

## 背景

オンラインモードで移動アクションがサーバー側で常にリジェクトされていた。原因は2つ：
1. サーバーのグリッドサイズが 20×20=400 ノードに対し、クライアントは 50×50=2500 ノードでノードIDが一致しなかった
2. 移動検証が「直接隣接のみ許可」だったため、クライアントが BFS 3ステップで選択した移動先がすべてリジェクトされていた

## テスト方法

1. `server/` で `npm start` を起動
2. `npm run dev` でフロントエンド起動
3. ブラウザ2タブで `ws://localhost:2567` に接続
4. ゲーム開始後、最大3ステップの移動・射撃が両クライアントに反映されることを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)