### PR TITLE
fix: オンラインモードでの NPC クライアント実行を抑止する (#30)

### DIFF
--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -206,11 +206,13 @@ export class GameController {
       shotAtNodeId: shotNodeId,
     });
 
-    // After human turn, trigger NPC turns
-    await this.turnManager.processNPCTurns().catch((err: unknown) => {
-      console.error('[GameController] NPC turn processing failed:', err);
-      this.eventBus.emit(GameEventType.INPUT_LOCKED, { locked: false });
-    });
+    // After human turn, trigger NPC turns (offline only)
+    if (this.networkAdapter.supportsNPC()) {
+      await this.turnManager.processNPCTurns().catch((err: unknown) => {
+        console.error('[GameController] NPC turn processing failed:', err);
+        this.eventBus.emit(GameEventType.INPUT_LOCKED, { locked: false });
+      });
+    }
   }
 
   /**

--- a/src/network/ColyseusAdapter.ts
+++ b/src/network/ColyseusAdapter.ts
@@ -205,4 +205,6 @@ export class ColyseusAdapter implements INetworkAdapter {
   getRoom(): Colyseus.Room {
     return this.room;
   }
+
+  supportsNPC(): boolean { return false; }
 }

--- a/src/network/INetworkAdapter.ts
+++ b/src/network/INetworkAdapter.ts
@@ -37,4 +37,11 @@ export interface INetworkAdapter {
 
   /** Register a callback invoked when obstacle data arrives from the server */
   onObstaclesReady(callback: (obstacles: ObstaclePayload[]) => void): void;
+
+  /**
+   * Returns true if NPC turn processing should run on the client side.
+   * LocalAdapter: true (offline, single-client)
+   * ColyseusAdapter: false (server-authoritative, multi-client)
+   */
+  supportsNPC(): boolean;
 }

--- a/src/network/LocalAdapter.ts
+++ b/src/network/LocalAdapter.ts
@@ -101,4 +101,6 @@ export class LocalAdapter implements INetworkAdapter {
       hits.push({ targetId, damage, isEliminated: !target.isAlive });
     }
   }
+
+  supportsNPC(): boolean { return true; }
 }


### PR DESCRIPTION
## 変更内容

- `INetworkAdapter` に `supportsNPC(): boolean` を追加
- `LocalAdapter.supportsNPC()` → `true`（オフライン、NPC あり）
- `ColyseusAdapter.supportsNPC()` → `false`（サーバー権威、クライアント側 NPC 不要）
- `GameController.executeTurn()` でオフライン時のみ `processNPCTurns()` を呼ぶよう変更

## 背景

オンラインモードで `TurnManager.processNPCTurns()` がアダプター種別に関わらず呼ばれていた。複数クライアントが接続した場合、全員が NPC の `turn_action` をサーバーに送信してしまう設計上の問題があった。

現状は `ColyseusAdapter` が `isNPC = false`（デフォルト）で Player を生成するため即時バグは発生しないが、インターフェースで意図を明示し将来の誤実装を防ぐ。

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)