### PR TITLE
feat: Railway デプロイ設定を追加する

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_SERVER_URL=wss://PLACEHOLDER.railway.app

--- a/document/DEPLOY.md
+++ b/document/DEPLOY.md
@@ -1,0 +1,97 @@
+# デプロイ手順
+
+## 構成概要
+
+| 役割 | ホスト | URL |
+|------|--------|-----|
+| クライアント (React SPA) | GitHub Pages | https://tamari-moto.github.io/2dFps/ |
+| サーバー (Colyseus WebSocket) | Railway | wss://xxx.railway.app |
+
+Railway のリバースプロキシが TLS (`wss://`) を終端し、コンテナ内は通常の `ws://` でリッスンします。
+
+---
+
+## Railway サーバーのデプロイ
+
+### 初回セットアップ（Railway Dashboard）
+
+1. [railway.app](https://railway.app) にログイン
+2. **New Project** → **Deploy from GitHub repo** でリポジトリを選択
+3. サービス設定で **Root Directory** を `server` に変更
+4. デプロイが自動で始まる → ビルドログ・起動ログで確認
+5. **Settings → Domains** から Railway URL を取得（例: `2dfps.up.railway.app`）
+
+### 自動デプロイ（以降）
+
+`main` ブランチへ push すると Railway が自動ビルド・デプロイします。
+
+### ビルドコマンド（`server/railway.toml` で定義済み）
+
+```
+npm install && npm run build   # TypeScript → dist/ へコンパイル
+npm start                      # node dist/index.js
+```
+
+### 環境変数
+
+| 変数 | 設定場所 | 説明 |
+|------|---------|------|
+| `PORT` | Railway 自動注入 | サーバーのリッスンポート（設定不要） |
+| `NODE_ENV` | Railway Dashboard（任意） | `production` |
+
+### ヘルスチェック確認
+
+Railway URL の `/` にアクセスして以下が返れば正常:
+
+```json
+{ "status": "ok", "service": "2dFps server" }
+```
+
+---
+
+## クライアントのデプロイ（GitHub Pages）
+
+### 初回 or Railway URL 変更時
+
+1. `.env.production` を開き `VITE_SERVER_URL` を Railway の実際の URL に更新する
+
+   ```
+   VITE_SERVER_URL=wss://2dfps.up.railway.app
+   ```
+
+2. ビルド & デプロイ:
+
+   ```bash
+   npm run deploy
+   ```
+
+   → `dist/` へビルド後、`gh-pages` ブランチに自動プッシュされます。
+
+### 通常のクライアント更新
+
+コード変更後に `npm run deploy` を実行するだけです（`.env.production` の変更は不要）。
+
+---
+
+## ローカル開発
+
+```bash
+# サーバー起動 (ws://localhost:2567)
+cd server && npm run dev
+
+# クライアント起動 (http://localhost:5173/2dFps/)
+npm run dev
+```
+
+ローカルでは `VITE_SERVER_URL` が未設定のため、ロビーのデフォルト値 `ws://localhost:2567` が使われます。
+
+---
+
+## トラブルシューティング
+
+| 症状 | 確認事項 |
+|------|---------|
+| Railway でビルドが失敗 | Root Directory が `server` になっているか確認 |
+| 接続エラー（`wss://` ではない） | `.env.production` の URL が `wss://` で始まっているか確認 |
+| 初回接続が遅い | Railway 無料プランはアイドル時スリープ。数秒待つと起動する |
+| GitHub Pages に反映されない | `npm run deploy` 後、数分待ってキャッシュクリア |

--- a/server/package.json
+++ b/server/package.json
@@ -8,12 +8,17 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts"
   },
+  "engines": {
+    "node": ">=20.0.0 <21.0.0"
+  },
   "dependencies": {
     "@colyseus/schema": "~2.0.0",
     "colyseus": "~0.15.57",
+    "cors": "^2.8.5",
     "express": "^4.18.2"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
     "ts-node": "^10.9.2",

--- a/server/railway.toml
+++ b/server/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "nixpacks"
+buildCommand = "npm install && npm run build"
+
+[deploy]
+startCommand = "npm start"
+healthcheckPath = "/"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,11 +1,18 @@
 import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'colyseus';
+import cors from 'cors';
 import { GameRoom } from './rooms/GameRoom';
 
 const PORT = Number(process.env.PORT) || 2567;
 
 const app = express();
+app.use(cors({
+  origin: [
+    'https://tamari-moto.github.io',
+    'http://localhost:5173',
+  ]
+}));
 app.use(express.json());
 
 // Health check

--- a/src/ui/LobbyUI.tsx
+++ b/src/ui/LobbyUI.tsx
@@ -8,7 +8,9 @@ interface LobbyUIProps {
 }
 
 const LobbyUI: React.FC<LobbyUIProps> = ({ connecting, errorMsg, onOffline, onOnline }) => {
-  const [serverUrl, setServerUrl] = React.useState('ws://localhost:2567');
+  const [serverUrl, setServerUrl] = React.useState(
+    import.meta.env.VITE_SERVER_URL ?? 'ws://localhost:2567'
+  );
 
   const overlayStyle: React.CSSProperties = {
     position: 'fixed',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SERVER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

- `server/railway.toml` を新規作成し、Railway のビルド・起動・ヘルスチェックを設定
- `server/package.json` に `cors` 依存と `engines.node` を追加
- `server/src/index.ts` に CORS ミドルウェアを追加（GitHub Pages + localhost を許可）
- `src/vite-env.d.ts` に `VITE_SERVER_URL` 環境変数の型宣言を追加
- `src/ui/LobbyUI.tsx` で本番ビルド時のデフォルト接続先を `VITE_SERVER_URL` から読むよう変更
- `.env.production` を新規作成（Railway URL プレースホルダ）
- `document/DEPLOY.md` にデプロイ手順ドキュメントを追加

## Test plan

- [ ] Railway Dashboard でリポジトリを接続し、Root Directory を `server` に設定してデプロイ
- [ ] `https://<railway-url>/` にアクセスし `{ "status": "ok" }` が返ることを確認
- [ ] `.env.production` の `PLACEHOLDER` を実際の Railway URL（`wss://xxx.railway.app`）に更新
- [ ] `npm run deploy` でクライアントを GitHub Pages に再デプロイ
- [ ] GitHub Pages からオンライン接続し、2タブで対戦が成立することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)