### PR TITLE
fix: ConsoleLogger をゲーム画面に表示 + applyServerConfig インポート修正

### DIFF
--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -7,7 +7,7 @@ import type { Model } from '../model/model';
 import { Player } from '../model/Player';
 import { INetworkAdapter } from '../network/INetworkAdapter';
 import { LocalAdapter } from '../network/LocalAdapter';
-import { MobileUIConfig } from '../config/GameConfig';
+import { MobileUIConfig, applyServerConfig } from '../config/GameConfig';
 
 /**
  * Main setup class for the Three.js-based 2D FPS game

--- a/src/ui/GRF_main.tsx
+++ b/src/ui/GRF_main.tsx
@@ -4,6 +4,7 @@ import type { ThreeSetup } from '../rendering/threeSetup';
 import GameHUD from './GameHUD';
 import LobbyUI from './LobbyUI';
 import MobileControls from './MobileControls';
+import ConsoleLogger from './ConsoleLogger';
 import { LocalAdapter } from '../network/LocalAdapter';
 import { ColyseusAdapter } from '../network/ColyseusAdapter';
 import type { INetworkAdapter } from '../network/INetworkAdapter';
@@ -106,6 +107,7 @@ const GRF_main = () => {
           onSwitchPlayer={handleSwitchPlayer}
         />
       )}
+      {appState === 'playing' && <ConsoleLogger />}
       {appState !== 'playing' && (
         <LobbyUI
           connecting={appState === 'connecting'}


### PR DESCRIPTION
## Summary
- `GRF_main.tsx` にゲームプレイ中のみ `<ConsoleLogger />` を表示するよう追加
- `threeSetup.ts` で `applyServerConfig` が未インポートだったビルドエラーを修正

## Test plan
- [x] オフラインモードでゲーム開始 → 画面右下にコンソールログが表示されることを確認
- [x] ビルドエラーなしで `npm run build` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)