### PR TITLE
fix: ゲーム開始済み後のjoinプレイヤーへobstacles_readyを送信

### DIFF
--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -46,6 +46,10 @@ export class GameRoom extends Room<GameState> {
     // Start game when enough players have joined
     if (!this.state.gameStarted && this.state.players.size >= MIN_PLAYERS_TO_START) {
       this.startGame();
+    } else if (this.state.gameStarted) {
+      // Game already started: send current map state to newly joined client
+      client.send('obstacles_ready', { obstacles: this.logic.getObstacles() });
+      client.send('game_started', {});
     }
   }
 


### PR DESCRIPTION
## 概要

ゲーム開始済みのオンラインルームに3人目以降がjoinした場合、
マップデータ（`obstacles_ready`）が届かずゲーム画面が初期化されない不具合を修正しました。

## 原因

`GameRoom.onJoin()` が `!this.state.gameStarted` の条件下でのみ `startGame()` を呼んでいたため、
ゲーム進行中にjoinしたプレイヤーに `obstacles_ready` と `game_started` メッセージが送信されませんでした。

## 修正内容

`server/src/rooms/GameRoom.ts` の `onJoin()` に以下を追加：

- ゲーム開始済みの場合、後joinプレイヤーに対して
  - `obstacles_ready`: 現在のマップ障害物データ（`this.logic.getObstacles()`）
  - `game_started`: ゲーム開始通知

を個別に送信するようにしました。

## 検証手順

1. サーバー起動: `cd server && npm run dev`
2. ブラウザA・B でOnlineモードにjoin → ゲーム開始を確認
3. ブラウザC でOnlineモードにjoin → マップが表示されることを確認
4. C のHUDにプレイヤー情報が表示されることを確認

## 技術詳細

- `obstacles_ready` を `game_started` より先に送信（既存の `startGame()` と同じ順序）
- クライアント側の `pendingObstacles` キャッシュメカニズムは既存のままで対応
- `initializePlayers` は既に実行済みなので不要（`PlayerState` は `MapSchema` 同期で届く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)