### PR TITLE
feat: NPC行動設計 — パーソナリティ・記憶・連携システム (#55)

### DIFF
--- a/docs/npc-behavior-design.md
+++ b/docs/npc-behavior-design.md
@@ -1,0 +1,173 @@
+# NPC 行動設計ドキュメント
+
+## 概要
+
+NPCの行動システムは3つの柱で構成される：
+
+1. **パーソナリティ（行動パターンの多様化）** — NPC ごとに異なる戦術特性
+2. **マルチターン戦略（記憶システム）** — 敵の最終確認位置を記憶し追跡
+3. **NPC 間連携** — 挟み撃ち、集中射撃、散開
+
+## アーキテクチャ
+
+```
+TurnManager.processNPCTurns()
+  |
+  v
+NPCBrain.decideTurn(model, npc)
+  |
+  +-- npc.updateMemory()           ... 敵記憶の更新
+  +-- buildCoordinationContext()    ... 味方NPC位置の収集
+  |
+  +-- NodeScorer.scoreNode()       ... 移動先評価
+  |     +-- パーソナリティ重み適用
+  |     +-- カバー / LOS / 待ち伏せ / 距離
+  |     +-- 散開ペナルティ (ClusterPenalty)
+  |     +-- 挟み撃ちボーナス (FlankBonus)
+  |     +-- 記憶ベース追跡 (SeekLastKnownBonus)
+  |
+  +-- ShotSelector.selectShotTarget()  ... 射撃対象選択
+        +-- パーソナリティ別優先度
+        +-- 集中射撃ボーナス (FocusFireBonus)
+```
+
+## パーソナリティ
+
+NPCは生成時にラウンドロビンで3種のパーソナリティのいずれかが割り当てられる。
+
+### 重みテーブル
+
+| パラメータ | Aggressive | Defensive | Ambusher |
+|-----------|-----------|-----------|----------|
+| coverWeight | 15 | 50 | 20 |
+| enemyLOSPenalty | -10 | -30 | -15 |
+| distanceWeight | -5 | -1 | 0 |
+| ambushBonus | 5 | 10 | 40 |
+| retreatHPThreshold | 20 | 60 | 40 |
+| retreatCoverMultiplier | 1.5 | 3 | 2 |
+| shotLowHPPriority | 5 | 15 | 10 |
+
+### 行動特性
+
+**Aggressive（攻撃型）**
+- 敵に積極的に接近する（distanceWeight: -5）
+- カバーをあまり重視しない（coverWeight: 15）
+- HPが20以下にならないと撤退しない
+- 近い敵を優先して射撃
+
+**Defensive（防御型）**
+- カバーを最重視（coverWeight: 50）
+- 敵の視線を強く警戒（enemyLOSPenalty: -30）
+- HP60以下で撤退モードに移行
+- 負傷した敵を優先的に狙う（shotLowHPPriority: 15）
+
+**Ambusher（待ち伏せ型）**
+- 待ち伏せポジションを最優先（ambushBonus: 40）
+- 距離に対して中立（distanceWeight: 0）
+- 見えて見えられない位置を積極的に探す
+
+## マルチターン戦略（記憶システム）
+
+### 仕組み
+
+各NPCは `enemyMemory: Map<string, EnemyMemoryEntry>` を持つ。
+
+```typescript
+interface EnemyMemoryEntry {
+  nodeId: number;    // 最後に観測した敵のノードID
+  turnsAgo: number;  // 何ターン前の情報か
+}
+```
+
+### ライフサイクル
+
+1. **更新タイミング**: `decideTurn()` 呼び出し時に `npc.updateMemory()` を実行
+2. **視界内の敵**: `turnsAgo = 0` で記録/更新
+3. **視界外の敵**: `turnsAgo` をインクリメント
+4. **期限切れ**: `turnsAgo > MemoryDuration (3)` の記憶は削除
+
+### 行動への影響
+
+- **移動先評価**: 敵が見えないとき、最終確認位置に近いノードに `SeekLastKnownBonus` を加算
+  - ボーナスは距離の逆数 × 記憶の新しさ（recencyFactor）で計算
+- **向き決定**: 敵が見えないとき、最も新しい記憶の位置に向く
+
+## NPC 間連携
+
+### 散開（Cluster Penalty）
+
+他の味方NPCとの距離が `ClusterDistance (3)` マンハッタン未満の場合、`ClusterPenalty (-15)` を加算。
+NPCが固まって行動することを防ぐ。
+
+### 挟み撃ち（Flank Bonus）
+
+最も近い敵を基点として、候補ノードと味方NPCの成す角度を計算。
+角度が `FlankAngleThreshold (60度)` 以上の場合、`FlankBonus (+20)` を加算。
+敵を複数方向から挟むポジションを促進する。
+
+```
+     NPC-A
+      \
+       \ 60度以上
+        \
+  Enemy ------- 候補ノード (FlankBonus付与)
+```
+
+### 集中射撃（Focus Fire）
+
+HPが `FocusFireHPThreshold (50%)` 以下の敵に `FocusFireBonus (+10)` を加算。
+複数NPCが同じ負傷した敵を優先的に狙う。
+
+## 設定パラメータ一覧
+
+### PersonalityWeights（`src/config/GameConfig.ts`）
+
+パーソナリティごとの重みセット。上記重みテーブルを参照。
+
+### CoordinationConfig（`src/config/GameConfig.ts`）
+
+| パラメータ | デフォルト値 | 説明 |
+|-----------|-----------|------|
+| FlankAngleThreshold | 60 | 挟み撃ちとみなす角度差（度） |
+| FlankBonus | 20 | 挟み撃ち位置へのスコアボーナス |
+| ClusterPenalty | -15 | 味方に近すぎる場合のペナルティ |
+| ClusterDistance | 3 | 散開判定のマンハッタン距離 |
+| FocusFireHPThreshold | 0.5 | 集中射撃する敵のHP割合閾値 |
+| FocusFireBonus | 10 | 集中射撃のスコアボーナス |
+| MemoryDuration | 3 | 敵位置を記憶するターン数 |
+| SeekLastKnownBonus | 10 | 記憶位置に向かうボーナス |
+
+## 調整ガイド
+
+### NPC を強くしたい場合
+- `aggressive.distanceWeight` を小さく（例: -8）→ より積極的に接近
+- `CoordinationConfig.FlankBonus` を大きく → 連携強化
+- `FocusFireBonus` を大きく → 集中射撃促進
+
+### NPC を弱くしたい場合
+- 各パーソナリティの `distanceWeight` を 0 に近づける → 消極的
+- `MemoryDuration` を 1 に → 記憶が短い
+- `FlankBonus` と `FocusFireBonus` を 0 に → 連携なし
+
+### 特定パーソナリティの調整
+- `PersonalityWeights` の該当エントリを直接変更
+- 全パラメータは `src/config/GameConfig.ts` に集約
+
+## 変更対象ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `src/config/GameConfig.ts` | NPCPersonality型、PersonalityWeights、CoordinationConfig |
+| `src/model/Player.ts` | personality, enemyMemory, updateMemory() |
+| `src/model/model.ts` | パーソナリティの割り当て |
+| `src/logic/ai/NPCBrain.ts` | 意思決定統合（メモリ更新＋連携コンテキスト） |
+| `src/logic/ai/NodeScorer.ts` | 移動先評価（パーソナリティ重み＋連携＋記憶） |
+| `src/logic/ai/ShotSelector.ts` | 射撃対象選択（パーソナリティ＋集中射撃） |
+
+## 将来の拡張候補
+
+- **難易度スケーリング**: Easy/Normal/Hard でパーソナリティ重みを全体的にスケール
+- **行動ツリー**: より複雑な条件分岐ロジック（状態遷移ベース）
+- **学習型AI**: プレイヤーの行動パターンに適応する重み調整
+- **コミュニケーション**: NPC間で敵発見情報を共有（記憶の伝播）
+- **役割分担**: リーダー/サポートなどチーム内役割の明示的な割り当て

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "2dfps",
       "version": "0.0.0",
       "dependencies": {
-        "colyseus.js": "^0.15.28",
+        "colyseus.js": "~0.15.28",
         "gsap": "^3.12.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -452,7 +452,77 @@ export const PostProcessConfig = {
 } as const;
 
 /**
- * NPC AI configuration
+ * NPC personality types
+ */
+export type NPCPersonality = 'aggressive' | 'defensive' | 'ambusher';
+
+/**
+ * Weight overrides per NPC personality
+ */
+export interface PersonalityWeightSet {
+  coverWeight: number;
+  enemyLOSPenalty: number;
+  distanceWeight: number;
+  ambushBonus: number;
+  retreatHPThreshold: number;
+  retreatCoverMultiplier: number;
+  shotLowHPPriority: number;
+}
+
+export const PersonalityWeights: Record<NPCPersonality, PersonalityWeightSet> = {
+  aggressive: {
+    coverWeight: 15,
+    enemyLOSPenalty: -10,
+    distanceWeight: -5,
+    ambushBonus: 5,
+    retreatHPThreshold: 20,
+    retreatCoverMultiplier: 1.5,
+    shotLowHPPriority: 5,
+  },
+  defensive: {
+    coverWeight: 50,
+    enemyLOSPenalty: -30,
+    distanceWeight: -1,
+    ambushBonus: 10,
+    retreatHPThreshold: 60,
+    retreatCoverMultiplier: 3,
+    shotLowHPPriority: 15,
+  },
+  ambusher: {
+    coverWeight: 20,
+    enemyLOSPenalty: -15,
+    distanceWeight: 0,
+    ambushBonus: 40,
+    retreatHPThreshold: 40,
+    retreatCoverMultiplier: 2,
+    shotLowHPPriority: 10,
+  },
+};
+
+/**
+ * NPC coordination configuration
+ */
+export const CoordinationConfig = {
+  /** Angle difference (degrees) to consider a flanking position */
+  FlankAngleThreshold: 60,
+  /** Score bonus for flanking positions */
+  FlankBonus: 20,
+  /** Penalty when too close to another NPC */
+  ClusterPenalty: -15,
+  /** Manhattan distance threshold for cluster penalty */
+  ClusterDistance: 3,
+  /** Enemy HP ratio below which focus fire activates */
+  FocusFireHPThreshold: 0.5,
+  /** Shot score bonus for focus fire targets */
+  FocusFireBonus: 10,
+  /** Number of turns to remember enemy positions */
+  MemoryDuration: 3,
+  /** Bonus for moving toward last known enemy position */
+  SeekLastKnownBonus: 10,
+} as const;
+
+/**
+ * NPC AI configuration (default / fallback values)
  */
 export const AIConfig = {
   /** Bonus for nodes adjacent to walls (fewer graph edges = more cover) */

--- a/src/logic/ai/NPCBrain.ts
+++ b/src/logic/ai/NPCBrain.ts
@@ -2,15 +2,29 @@ import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
 import { PlayerConfig } from '../../config/GameConfig';
 import { TurnAction } from '../../schema/types';
-import { scoreNode } from './NodeScorer';
+import { scoreNode, CoordinationContext } from './NodeScorer';
 import { selectShotTarget } from './ShotSelector';
 
 /**
  * Top-level NPC decision maker.
  * Produces a complete TurnAction for one NPC.
+ * Integrates personality weights, enemy memory, and NPC coordination.
  */
 export function decideTurn(model: Model, npc: Player): TurnAction {
   const enemies = getAliveEnemies(model, npc.id);
+
+  // Update enemy memory based on current visibility
+  const visibleNodeIds = new Set(
+    model.getVisibleNodesAtAngle(npc.node, npc.angle, PlayerConfig.MaxViewDistance)
+      .map(n => n.id)
+  );
+  const visibleEnemyIds = new Set(
+    enemies.filter(e => visibleNodeIds.has(e.node.id)).map(e => e.id)
+  );
+  npc.updateMemory(visibleEnemyIds, enemies);
+
+  // Build coordination context from allied NPC positions
+  const coordination = buildCoordinationContext(model, npc.id);
 
   // 1. Evaluate candidate move nodes: reachable within MoveRange + current (stay)
   const reachable = model.getReachableNodes(npc.node.id, PlayerConfig.MoveRange);
@@ -20,10 +34,9 @@ export function decideTurn(model: Model, npc: Player): TurnAction {
   let bestScore = -Infinity;
 
   for (const nodeId of candidates) {
-    // Skip nodes occupied by other alive players
     if (isNodeOccupied(model, nodeId, npc.id)) continue;
 
-    const score = scoreNode(model, npc, nodeId, enemies);
+    const score = scoreNode(model, npc, nodeId, enemies, coordination);
     if (score > bestScore) {
       bestScore = score;
       bestNodeId = nodeId;
@@ -47,6 +60,20 @@ export function decideTurn(model: Model, npc: Player): TurnAction {
     if (nearestEnemy) {
       facingAngle = model.getAngleBetweenNodes(moveToNode, nearestEnemy.node);
     }
+  } else if (npc.enemyMemory.size > 0) {
+    // No visible enemies: face toward most recent memory location
+    let bestMemory: { nodeId: number; turnsAgo: number } | undefined;
+    for (const [, entry] of npc.enemyMemory) {
+      if (!bestMemory || entry.turnsAgo < bestMemory.turnsAgo) {
+        bestMemory = entry;
+      }
+    }
+    if (bestMemory) {
+      const memNode = model.nodeList[bestMemory.nodeId];
+      if (memNode) {
+        facingAngle = model.getAngleBetweenNodes(moveToNode, memNode);
+      }
+    }
   }
 
   // 3. Select shot target
@@ -57,6 +84,15 @@ export function decideTurn(model: Model, npc: Player): TurnAction {
     moveToNodeId: bestNodeId,
     shotAtNodeId,
   };
+}
+
+function buildCoordinationContext(model: Model, npcId: string): CoordinationContext {
+  const allyPositions: { nodeId: number }[] = [];
+  for (const [id, player] of model.players) {
+    if (id === npcId || !player.isNPC || !player.isAlive) continue;
+    allyPositions.push({ nodeId: player.node.id });
+  }
+  return { allyPositions };
 }
 
 function getAliveEnemies(model: Model, npcId: string): Player[] {

--- a/src/logic/ai/NodeScorer.ts
+++ b/src/logic/ai/NodeScorer.ts
@@ -1,28 +1,37 @@
 import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
-import { AIConfig } from '../../config/GameConfig';
+import { PersonalityWeights, CoordinationConfig } from '../../config/GameConfig';
 import { MapConfig } from '../../config/GameConfig';
 
 /**
+ * Context about allied NPCs for coordination scoring
+ */
+export interface CoordinationContext {
+  allyPositions: { nodeId: number }[];
+}
+
+/**
  * Evaluates a candidate move node for an NPC.
- * Pure function: reads from Model, returns a numeric score.
+ * Uses personality-based weights, coordination bonuses, and memory-based seeking.
  */
 export function scoreNode(
   model: Model,
   npc: Player,
   candidateNodeId: number,
-  enemies: Player[]
+  enemies: Player[],
+  coordination?: CoordinationContext
 ): number {
   let score = 0;
   const candidateNode = model.nodeList[candidateNodeId];
   const gridSize = MapConfig.NodesInGridSize;
+  const weights = PersonalityWeights[npc.personality];
 
   // 1. Cover score: fewer graph edges = more walls around this node
   const edgeCount = model.Edges.List[candidateNodeId]?.length ?? 0;
-  const coverScore = 4 - edgeCount; // max 4 directions, so 0-4 walls
-  const coverWeight = npc.health < AIConfig.RetreatHPThreshold
-    ? AIConfig.CoverWeight * AIConfig.RetreatCoverMultiplier
-    : AIConfig.CoverWeight;
+  const coverScore = 4 - edgeCount;
+  const coverWeight = npc.health < weights.retreatHPThreshold
+    ? weights.coverWeight * weights.retreatCoverMultiplier
+    : weights.coverWeight;
   score += coverScore * coverWeight;
 
   // 2. Enemy LOS exposure & ambush potential
@@ -31,20 +40,20 @@ export function scoreNode(
     const npcSeesEnemy = model.hasLineOfSight(candidateNode, enemy.node);
 
     if (enemySeesCandidate) {
-      score += AIConfig.EnemyLOSPenalty;
+      score += weights.enemyLOSPenalty;
     }
 
-    // 3. Ambush: NPC can see enemy but enemy can't see NPC
     if (npcSeesEnemy && !enemySeesCandidate) {
-      score += AIConfig.AmbushBonus;
+      score += weights.ambushBonus;
     }
   }
 
-  // 4. Distance to nearest enemy (Manhattan distance on grid)
+  // 3. Distance to nearest enemy (Manhattan distance on grid)
   let minDistance = Infinity;
+  const candidateCol = Math.floor(candidateNodeId / gridSize);
+  const candidateRow = candidateNodeId % gridSize;
+
   for (const enemy of enemies) {
-    const candidateCol = Math.floor(candidateNodeId / gridSize);
-    const candidateRow = candidateNodeId % gridSize;
     const enemyCol = Math.floor(enemy.node.id / gridSize);
     const enemyRow = enemy.node.id % gridSize;
     const dist = Math.abs(candidateCol - enemyCol) + Math.abs(candidateRow - enemyRow);
@@ -54,14 +63,116 @@ export function scoreNode(
   }
 
   if (minDistance !== Infinity) {
-    if (npc.health < AIConfig.RetreatHPThreshold) {
-      // Low HP: prefer distance from enemies (invert weight)
-      score += minDistance * Math.abs(AIConfig.DistanceWeight);
+    if (npc.health < weights.retreatHPThreshold) {
+      score += minDistance * Math.abs(weights.distanceWeight);
     } else {
-      // Normal: prefer closer to enemies
-      score += minDistance * AIConfig.DistanceWeight;
+      score += minDistance * weights.distanceWeight;
     }
   }
 
+  // 4. Coordination: cluster penalty (avoid grouping with allies)
+  if (coordination) {
+    for (const ally of coordination.allyPositions) {
+      const allyCol = Math.floor(ally.nodeId / gridSize);
+      const allyRow = ally.nodeId % gridSize;
+      const allyDist = Math.abs(candidateCol - allyCol) + Math.abs(candidateRow - allyRow);
+      if (allyDist < CoordinationConfig.ClusterDistance) {
+        score += CoordinationConfig.ClusterPenalty;
+      }
+    }
+
+    // 5. Coordination: flank bonus
+    if (enemies.length > 0 && coordination.allyPositions.length > 0) {
+      score += calcFlankBonus(candidateCol, candidateRow, enemies, coordination, gridSize);
+    }
+  }
+
+  // 6. Memory: seek last known enemy positions when no enemies visible
+  if (enemies.length === 0 && npc.enemyMemory.size > 0) {
+    score += calcMemorySeekScore(candidateCol, candidateRow, npc, gridSize);
+  }
+
   return score;
+}
+
+/**
+ * Calculates flanking bonus: rewards positions that form a wide angle
+ * with an ally relative to the nearest enemy.
+ */
+function calcFlankBonus(
+  candidateCol: number,
+  candidateRow: number,
+  enemies: Player[],
+  coordination: CoordinationContext,
+  gridSize: number,
+): number {
+  let bonus = 0;
+  // Check flanking against the nearest enemy
+  let nearestEnemy = enemies[0];
+  let nearestDist = Infinity;
+  for (const enemy of enemies) {
+    const eCol = Math.floor(enemy.node.id / gridSize);
+    const eRow = enemy.node.id % gridSize;
+    const d = Math.abs(candidateCol - eCol) + Math.abs(candidateRow - eRow);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearestEnemy = enemy;
+    }
+  }
+
+  const eCol = Math.floor(nearestEnemy.node.id / gridSize);
+  const eRow = nearestEnemy.node.id % gridSize;
+
+  for (const ally of coordination.allyPositions) {
+    const aCol = Math.floor(ally.nodeId / gridSize);
+    const aRow = ally.nodeId % gridSize;
+
+    // Vectors from enemy to candidate and from enemy to ally
+    const v1x = candidateCol - eCol;
+    const v1y = candidateRow - eRow;
+    const v2x = aCol - eCol;
+    const v2y = aRow - eRow;
+
+    const mag1 = Math.sqrt(v1x * v1x + v1y * v1y);
+    const mag2 = Math.sqrt(v2x * v2x + v2y * v2y);
+    if (mag1 === 0 || mag2 === 0) continue;
+
+    const dot = (v1x * v2x + v1y * v2y) / (mag1 * mag2);
+    const angleDeg = Math.acos(Math.max(-1, Math.min(1, dot))) * (180 / Math.PI);
+
+    if (angleDeg >= CoordinationConfig.FlankAngleThreshold) {
+      bonus += CoordinationConfig.FlankBonus;
+      break; // One flank bonus per node is enough
+    }
+  }
+
+  return bonus;
+}
+
+/**
+ * Calculates bonus for moving toward last known enemy positions (memory-based seeking).
+ */
+function calcMemorySeekScore(
+  candidateCol: number,
+  candidateRow: number,
+  npc: Player,
+  gridSize: number,
+): number {
+  let bestBonus = 0;
+
+  for (const [, entry] of npc.enemyMemory) {
+    const memCol = Math.floor(entry.nodeId / gridSize);
+    const memRow = entry.nodeId % gridSize;
+    const dist = Math.abs(candidateCol - memCol) + Math.abs(candidateRow - memRow);
+
+    // Closer to last known position = higher bonus, scaled by recency
+    const recencyFactor = 1 - entry.turnsAgo / (CoordinationConfig.MemoryDuration + 1);
+    const seekBonus = CoordinationConfig.SeekLastKnownBonus * recencyFactor / Math.max(1, dist);
+
+    if (seekBonus > bestBonus) {
+      bestBonus = seekBonus;
+    }
+  }
+
+  return bestBonus;
 }

--- a/src/logic/ai/ShotSelector.ts
+++ b/src/logic/ai/ShotSelector.ts
@@ -1,16 +1,17 @@
 import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
 import { Node } from '../../model/node';
-import { PlayerConfig, AIConfig } from '../../config/GameConfig';
+import { PlayerConfig, PersonalityWeights, CoordinationConfig } from '../../config/GameConfig';
 import { MapConfig } from '../../config/GameConfig';
 
 /**
  * Selects the best shot target for an NPC from the move-to position.
+ * Uses personality-based priority and focus fire coordination.
  * Returns the target node ID, or undefined if no enemy is visible.
  */
 export function selectShotTarget(
   model: Model,
-  _npc: Player,
+  npc: Player,
   moveToNode: Node,
   angle: number,
   enemies: Player[]
@@ -23,6 +24,7 @@ export function selectShotTarget(
 
   const visibleNodeIds = new Set(visibleNodes.map(n => n.id));
   const gridSize = MapConfig.NodesInGridSize;
+  const weights = PersonalityWeights[npc.personality];
 
   let bestTarget: { nodeId: number; score: number } | undefined;
 
@@ -36,8 +38,14 @@ export function selectShotTarget(
     const enemyRow = enemy.node.id % gridSize;
     const dist = Math.abs(moveCol - enemyCol) + Math.abs(moveRow - enemyRow);
 
-    const hpBonus = (enemy.maxHealth - enemy.health) * AIConfig.ShotLowHPPriority / enemy.maxHealth;
-    const score = hpBonus - dist;
+    const hpBonus = (enemy.maxHealth - enemy.health) * weights.shotLowHPPriority / enemy.maxHealth;
+    let score = hpBonus - dist;
+
+    // Focus fire: bonus for enemies below HP threshold
+    const hpRatio = enemy.health / enemy.maxHealth;
+    if (hpRatio <= CoordinationConfig.FocusFireHPThreshold) {
+      score += CoordinationConfig.FocusFireBonus;
+    }
 
     if (!bestTarget || score > bestTarget.score) {
       bestTarget = { nodeId: enemy.node.id, score };

--- a/src/model/Player.ts
+++ b/src/model/Player.ts
@@ -1,5 +1,14 @@
 import { Node } from './node';
 import { Entity, EntityType } from './entities/Entity';
+import { NPCPersonality, CoordinationConfig } from '../config/GameConfig';
+
+/**
+ * Memory entry for a last-known enemy position
+ */
+export interface EnemyMemoryEntry {
+  nodeId: number;
+  turnsAgo: number;
+}
 
 /**
  * Player entity with health and alive state
@@ -9,13 +18,24 @@ export class Player extends Entity {
   maxHealth: number;
   isAlive: boolean;
   isNPC: boolean;
+  personality: NPCPersonality;
+  enemyMemory: Map<string, EnemyMemoryEntry>;
 
-  constructor(id: string, initialNode: Node, color: number, maxHealth: number = 100, isNPC: boolean = false) {
+  constructor(
+    id: string,
+    initialNode: Node,
+    color: number,
+    maxHealth: number = 100,
+    isNPC: boolean = false,
+    personality: NPCPersonality = 'aggressive',
+  ) {
     super(id, EntityType.PLAYER, initialNode, color, 0);
     this.maxHealth = maxHealth;
     this.health = maxHealth;
     this.isAlive = true;
     this.isNPC = isNPC;
+    this.personality = personality;
+    this.enemyMemory = new Map();
   }
 
   /**
@@ -29,6 +49,34 @@ export class Player extends Entity {
     if (this.health <= 0) {
       this.isAlive = false;
       console.log(`💀 ${this.id} has been eliminated!`);
+    }
+  }
+
+  /**
+   * Updates enemy memory based on currently visible enemies.
+   * Visible enemies get fresh entries; unseen enemies age by one turn;
+   * entries older than MemoryDuration are purged.
+   */
+  updateMemory(visibleEnemyIds: Set<string>, allEnemies: Player[]): void {
+    const visibleMap = new Map<string, number>();
+    for (const enemy of allEnemies) {
+      if (visibleEnemyIds.has(enemy.id)) {
+        visibleMap.set(enemy.id, enemy.node.id);
+      }
+    }
+
+    // Update visible enemies
+    for (const [enemyId, nodeId] of visibleMap) {
+      this.enemyMemory.set(enemyId, { nodeId, turnsAgo: 0 });
+    }
+
+    // Age unseen enemies and purge expired
+    for (const [enemyId, entry] of this.enemyMemory) {
+      if (visibleMap.has(enemyId)) continue;
+      entry.turnsAgo++;
+      if (entry.turnsAgo > CoordinationConfig.MemoryDuration) {
+        this.enemyMemory.delete(enemyId);
+      }
     }
   }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -2,7 +2,7 @@ import { Node } from './node';
 import { Graph } from './Graph';
 import { LineSegment } from './LineSegment';
 import type { ObstacleData } from './ObstacleExporter';
-import { MapConfig, PlayerConfig } from '../config/GameConfig';
+import { MapConfig, PlayerConfig, NPCPersonality } from '../config/GameConfig';
 import { LOCAL_PLAYER_COUNT, createPlayerId } from '../config/GameConstants';
 import { MapGenerator } from './MapGenerator';
 import { Player } from './Player';
@@ -64,6 +64,8 @@ class Model {
     const playerColors = this.generatePlayerColors(LOCAL_PLAYER_COUNT);
     const usedNodeIds = new Set<number>();
 
+    const personalities: NPCPersonality[] = ['aggressive', 'defensive', 'ambusher'];
+
     for (let i = 0; i < LOCAL_PLAYER_COUNT && i < this.nodeList.length; i++) {
       const playerId = createPlayerId(i);
       const isNPC = i > 0;
@@ -78,8 +80,13 @@ class Model {
         nodeIndex = i;
       }
 
+      // Assign personality to NPCs via round-robin
+      const personality: NPCPersonality = isNPC
+        ? personalities[(i - 1) % personalities.length]
+        : 'aggressive';
+
       usedNodeIds.add(nodeIndex);
-      this.players.set(playerId, new Player(playerId, this.nodeList[nodeIndex], playerColors[i], 100, isNPC));
+      this.players.set(playerId, new Player(playerId, this.nodeList[nodeIndex], playerColors[i], 100, isNPC, personality));
     }
   }
 


### PR DESCRIPTION
NPCの行動を3つの柱で改善:
- パーソナリティ(aggressive/defensive/ambusher)による重み分岐
- 敵の最終確認位置を記憶し追跡するメモリシステム
- 挟み撃ち・散開・集中射撃のNPC間連携

設計ドキュメント docs/npc-behavior-design.md を追加。

https://claude.ai/code/session_01RYrg9ga3q5K3G4RAR83Nd7