### PR TITLE
feat: WASD キーによるアングルベース移動機能

### DIFF
--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -453,8 +453,18 @@ export const HUMAN_PLAYER_ID = ENTITY_IDS.PLAYER_1;
  * Keyboard key constants for game controls
  */
 export const KEYBOARD_KEYS = {
-  DANCE: 'd',
-  DANCE_UPPER: 'D',
+  DANCE: 'f',
+  DANCE_UPPER: 'F',
+  MOVE_UP: 'w',
+  MOVE_UP_UPPER: 'W',
+  MOVE_DOWN: 's',
+  MOVE_DOWN_UPPER: 'S',
+  MOVE_LEFT: 'a',
+  MOVE_LEFT_UPPER: 'A',
+  MOVE_RIGHT: 'd',
+  MOVE_RIGHT_UPPER: 'D',
+  CONFIRM_TURN: 'Enter',
+  CANCEL: 'Escape',
 } as const;
 
 /**

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -2,7 +2,7 @@ import { Model } from '../model/model';
 import type { ObstacleData } from '../model/MapGenerator';
 import { State, GameEvent, StateMachine } from './StateMachine';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
-import { AIConfig, PlayerConfig } from '../config/GameConfig';
+import { AIConfig, PlayerConfig, KEYBOARD_KEYS } from '../config/GameConfig';
 import { Player } from '../model/Player';
 import { Node } from '../model/node';
 import { INetworkAdapter } from '../network/INetworkAdapter';
@@ -55,6 +55,7 @@ export class GameController {
   private setupEventListeners(): void {
     this.eventBus.on(GameEventType.NODE_CLICKED, this.handleNodeClick.bind(this));
     this.eventBus.on(GameEventType.CANVAS_CLICKED_EMPTY, this.handleCanvasEmptyClick.bind(this));
+    this.eventBus.on(GameEventType.KEY_PRESSED, this.handleKeyPress.bind(this));
     this.eventBus.on(GameEventType.PLAYER_SWITCHED, this.handlePlayerSwitch.bind(this));
     this.eventBus.on(GameEventType.HIT_DETECTED, this.handleHitDetected.bind(this));
     this.eventBus.on(GameEventType.INPUT_LOCKED, (data: { locked: boolean }) => {
@@ -70,6 +71,100 @@ export class GameController {
       this.stateMachines.set(playerId, new StateMachine());
     }
     return this.stateMachines.get(playerId)!;
+  }
+
+  /**
+   * Handles keyboard input for WASD movement, Enter confirm, and Escape cancel.
+   */
+  private handleKeyPress(data: { key: string }): void {
+    if (this.inputLocked) return;
+
+    const activePlayer = this.model.getPlayer(this.activePlayerId);
+    if (!activePlayer) return;
+
+    const sm = this.getStateMachine(this.activePlayerId);
+    const currentState = sm.getState();
+
+    if (data.key === KEYBOARD_KEYS.CONFIRM_TURN) {
+      if (currentState === State.Move || currentState === State.Shot) {
+        this.executeTurn(sm);
+      }
+      return;
+    }
+
+    if (data.key === KEYBOARD_KEYS.CANCEL) {
+      this.handleCanvasEmptyClick();
+      return;
+    }
+
+    const wasdNode = this.getWASDTargetNode(activePlayer, data.key);
+    if (wasdNode === null) return;
+
+    if (currentState === State.Idle) {
+      sm.transition(GameEvent.SelectPlayer);
+      this.eventBus.emit(GameEventType.VIS_SET_SELECT_MESH, { nodeId: activePlayer.node.id });
+      this.reachableNodes = this.model.getReachableNodes(activePlayer.node.id, PlayerConfig.MoveRange);
+      this.eventBus.emit(GameEventType.VIS_SET_REACHABLE_NODES, {
+        nodeIds: Array.from(this.reachableNodes),
+      });
+    }
+
+    const stateAfterIdle = sm.getState();
+    if (stateAfterIdle === State.Select || stateAfterIdle === State.Move) {
+      if (this.reachableNodes.has(wasdNode.id)) {
+        if (stateAfterIdle === State.Select) {
+          sm.transition(GameEvent.MovePlayer);
+        }
+        // Move状態では自己遷移なし: currentNextNodeId を直接上書き
+        this.currentNextNodeId = wasdNode.id;
+        this.eventBus.emit(GameEventType.VIS_SET_NEXT_MESH, { nodeId: wasdNode.id });
+      }
+    }
+
+    this.eventBus.emit(GameEventType.VIS_UPDATE_VIEW);
+  }
+
+  /**
+   * Returns the neighboring node closest to the given WASD direction,
+   * relative to the player's current angle.
+   * Uses graph edges (x, y coordinates) rather than grid ID arithmetic.
+   */
+  private getWASDTargetNode(player: Player, key: string): Node | null {
+    const angle = player.angle;
+
+    let relAngle: number | null = null;
+    if (key === KEYBOARD_KEYS.MOVE_UP    || key === KEYBOARD_KEYS.MOVE_UP_UPPER)    relAngle = 0;
+    if (key === KEYBOARD_KEYS.MOVE_DOWN  || key === KEYBOARD_KEYS.MOVE_DOWN_UPPER)  relAngle = 180;
+    if (key === KEYBOARD_KEYS.MOVE_LEFT  || key === KEYBOARD_KEYS.MOVE_LEFT_UPPER)  relAngle = 90;
+    if (key === KEYBOARD_KEYS.MOVE_RIGHT || key === KEYBOARD_KEYS.MOVE_RIGHT_UPPER) relAngle = -90;
+    if (relAngle === null) return null;
+
+    const targetAngle = ((angle + relAngle) % 360 + 360) % 360;
+
+    const neighborIds: number[] = this.model.Edges.List[player.node.id] ?? [];
+    const currentNode = player.node;
+
+    let bestNode: Node | null = null;
+    let bestDiff = Infinity;
+
+    for (const neighborId of neighborIds) {
+      const neighbor = this.model.nodeList[neighborId];
+      if (!neighbor) continue;
+
+      const dx = neighbor.x - currentNode.x;
+      const dy = neighbor.y - currentNode.y;
+      const neighborAngle = ((Math.atan2(dy, dx) * 180 / Math.PI) % 360 + 360) % 360;
+
+      let diff = Math.abs(neighborAngle - targetAngle);
+      if (diff > 180) diff = 360 - diff;
+
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        bestNode = neighbor;
+      }
+    }
+
+    return bestNode;
   }
 
   /**


### PR DESCRIPTION
## Summary

プレイヤーの向き（角度）を基準とした WASD キーでの移動機能を実装しました。

- **W**: プレイヤーの前方に移動
- **A**: プレイヤーの左方向に移動  
- **S**: プレイヤーの後方に移動
- **D**: プレイヤーの右方向に移動
- **Enter**: Move/Shot 状態でターンを確定
- **Escape**: 移動/射撃をキャンセル
- **F**: ダンス（旧キーは D）

## Technical Details

### 角度ベースの方向判定
- プレイヤーの `angle` を基準に、相対角度を計算
- グラフの隣接ノード（`Edges.List`）から、atan2で計算した角度が最も近いノードを選択
- グリッド ID 計算ではなく座標ベースのため、障害物で切られたエッジは自動的に回避

### 修正: 左右反転バグ
- Y 軸が画面下向き（数学座標系）のため、「プレイヤー視点の左右」と数学的角度に 90° のズレがある
- MOVE_LEFT/RIGHT の relAngle を入れ替えて正常化（A=左90°、D=右-90°）

## Test Plan

- [ ] ゲーム起動後、W/A/S/D で移動先がハイライトされることを確認
- [ ] プレイヤーの向きを変えた後、WASD が相対的に正しく動くことを確認
- [ ] Enter キーでターンが実行されることを確認
- [ ] Escape キーでキャンセルできることを確認
- [ ] F キーでダンスアニメーションが再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)