### PR TITLE
feat: 観戦モード（Spectator Mode）を追加

### DIFF
--- a/server/src/logic/ServerGameLogic.ts
+++ b/server/src/logic/ServerGameLogic.ts
@@ -343,7 +343,7 @@ export class ServerGameLogic {
    */
   initializePlayers(players: MapSchema<PlayerState>): void {
     const ids: string[] = [];
-    players.forEach((_p, id) => ids.push(id));
+    players.forEach((p, id) => { if (!p.isSpectator) ids.push(id); });
 
     ids.forEach((id, i) => {
       const p = players.get(id)!;

--- a/server/src/rooms/GameRoom.ts
+++ b/server/src/rooms/GameRoom.ts
@@ -18,13 +18,14 @@ export class GameRoom extends Room<GameState> {
     });
   }
 
-  onJoin(client: Client): void {
+  onJoin(client: Client, options: { spectate?: boolean } = {}): void {
     const player = new PlayerState();
     player.id = client.sessionId;
+    player.isSpectator = options.spectate === true;
     this.state.players.set(client.sessionId, player);
 
-    // Notify this client of their assigned ID
-    client.send('player_assigned', { playerId: client.sessionId });
+    // Notify this client of their assigned ID and spectator status
+    client.send('player_assigned', { playerId: client.sessionId, isSpectator: player.isSpectator });
 
     // Send server-authoritative config so client can override its local defaults
     client.send('server_config', {
@@ -41,25 +42,29 @@ export class GameRoom extends Room<GameState> {
       },
     });
 
-    console.log(`[GameRoom] ${client.sessionId} joined (${this.state.players.size}/${this.maxClients})`);
+    const role = player.isSpectator ? 'SPECTATOR' : 'player';
+    console.log(`[GameRoom] ${client.sessionId} joined as ${role} (${this.state.players.size}/${this.maxClients})`);
 
-    // Start game when enough players have joined
-    if (!this.state.gameStarted && this.state.players.size >= MIN_PLAYERS_TO_START) {
+    // Start game when enough non-spectator players have joined
+    if (!this.state.gameStarted && this.countActivePlayers() >= MIN_PLAYERS_TO_START) {
       this.startGame();
     } else if (this.state.gameStarted) {
-      // Game already started: send current map state to newly joined client
+      // Game already started: send current map state to newly joined client (including spectators)
       client.send('obstacles_ready', { obstacles: this.logic.getObstacles() });
       client.send('game_started', {});
     }
   }
 
   onLeave(client: Client): void {
+    const leaving = this.state.players.get(client.sessionId);
+    const wasSpectator = leaving?.isSpectator ?? false;
+
     this.state.players.delete(client.sessionId);
     this.broadcast('player_left', { playerId: client.sessionId });
     console.log(`[GameRoom] ${client.sessionId} left`);
 
-    // If only one player remains during a started game, end it
-    if (this.state.gameStarted) {
+    // Spectator departure does not affect game-end conditions
+    if (!wasSpectator && this.state.gameStarted) {
       const alive = this.countAlivePlayers();
       if (alive <= 1) {
         this.endGame();
@@ -91,6 +96,12 @@ export class GameRoom extends Room<GameState> {
       return;
     }
 
+    const actor = this.state.players.get(client.sessionId);
+    if (actor?.isSpectator) {
+      client.send('error', { code: 'SPECTATOR_CANNOT_ACT' });
+      return;
+    }
+
     if (action.playerId !== client.sessionId) {
       client.send('error', { code: 'INVALID_PLAYER_ID' });
       return;
@@ -114,15 +125,21 @@ export class GameRoom extends Room<GameState> {
     }
   }
 
+  private countActivePlayers(): number {
+    let count = 0;
+    this.state.players.forEach(p => { if (!p.isSpectator) count++; });
+    return count;
+  }
+
   private countAlivePlayers(): number {
     let count = 0;
-    this.state.players.forEach(p => { if (p.isAlive) count++; });
+    this.state.players.forEach(p => { if (!p.isSpectator && p.isAlive) count++; });
     return count;
   }
 
   private getAlivePlayerId(): string | null {
     let found: string | null = null;
-    this.state.players.forEach((p, id) => { if (p.isAlive) found = id; });
+    this.state.players.forEach((p, id) => { if (!p.isSpectator && p.isAlive) found = id; });
     return found;
   }
 

--- a/server/src/schema/GameState.ts
+++ b/server/src/schema/GameState.ts
@@ -7,6 +7,7 @@ export class PlayerState extends Schema {
   @type('number') health: number = 100;
   @type('boolean') isAlive: boolean = true;
   @type('number') color: number = 0xffffff;
+  @type('boolean') isSpectator: boolean = false;
 }
 
 export class GameState extends Schema {

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -19,7 +19,8 @@ export class GameController {
   private activePlayerId: string;
   private networkAdapter: INetworkAdapter;
   private stateMachines: Map<string, StateMachine> = new Map();
-  private turnManager: TurnManager;
+  private turnManager?: TurnManager;
+  private readonly isSpectatorMode: boolean;
   private inputLocked: boolean = false;
   private reachableNodes: Set<number> = new Set();
 
@@ -30,19 +31,22 @@ export class GameController {
     model: Model,
     eventBus: GameEventBus,
     activePlayerId: string,
-    networkAdapter: INetworkAdapter
+    networkAdapter: INetworkAdapter,
+    isSpectator: boolean = false,
   ) {
     this.model = model;
     this.eventBus = eventBus;
     this.activePlayerId = activePlayerId;
     this.networkAdapter = networkAdapter;
+    this.isSpectatorMode = isSpectator;
 
-    // Create a StateMachine for each player
-    for (const playerId of model.players.keys()) {
-      this.stateMachines.set(playerId, new StateMachine());
+    if (!isSpectator) {
+      // Create a StateMachine for each player (not needed for spectators)
+      for (const playerId of model.players.keys()) {
+        this.stateMachines.set(playerId, new StateMachine());
+      }
+      this.turnManager = new TurnManager(model);
     }
-
-    this.turnManager = new TurnManager(model);
 
     this.networkAdapter.onTurnResult(this.applyTurnResult.bind(this));
     this.networkAdapter.onGameStarted(this.handleGameStarted.bind(this));
@@ -53,8 +57,11 @@ export class GameController {
    * Sets up event listeners for game events
    */
   private setupEventListeners(): void {
-    this.eventBus.on(GameEventType.NODE_CLICKED, this.handleNodeClick.bind(this));
-    this.eventBus.on(GameEventType.CANVAS_CLICKED_EMPTY, this.handleCanvasEmptyClick.bind(this));
+    if (!this.isSpectatorMode) {
+      // Spectators cannot issue commands — skip input event subscriptions
+      this.eventBus.on(GameEventType.NODE_CLICKED, this.handleNodeClick.bind(this));
+      this.eventBus.on(GameEventType.CANVAS_CLICKED_EMPTY, this.handleCanvasEmptyClick.bind(this));
+    }
     this.eventBus.on(GameEventType.PLAYER_SWITCHED, this.handlePlayerSwitch.bind(this));
     this.eventBus.on(GameEventType.HIT_DETECTED, this.handleHitDetected.bind(this));
     this.eventBus.on(GameEventType.INPUT_LOCKED, (data: { locked: boolean }) => {
@@ -202,7 +209,7 @@ export class GameController {
     const allActions: TurnAction[] = [
       { playerId: this.activePlayerId, moveToNodeId: nextNodeId, shotAtNodeId: shotNodeId },
     ];
-    if (this.networkAdapter.supportsNPC()) {
+    if (this.networkAdapter.supportsNPC() && this.turnManager) {
       allActions.push(...this.turnManager.collectNPCActions());
     }
 
@@ -297,13 +304,15 @@ export class GameController {
   private handlePlayerSwitch(data: { currentPlayerId: string }): void {
     if (this.inputLocked) return;
 
-    // Block switching to NPC-controlled players
-    const targetPlayer = this.model.getPlayer(data.currentPlayerId);
-    if (targetPlayer?.isNPC) return;
+    if (!this.isSpectatorMode) {
+      // Block switching to NPC-controlled players (spectators can view any player)
+      const targetPlayer = this.model.getPlayer(data.currentPlayerId);
+      if (targetPlayer?.isNPC) return;
+    }
 
     this.activePlayerId = data.currentPlayerId;
     this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId: data.currentPlayerId });
-    console.log(`Switched to ${data.currentPlayerId}`);
+    console.log(`${this.isSpectatorMode ? '[Spectating]' : 'Switched to'} ${data.currentPlayerId}`);
   }
 
   /**

--- a/src/network/ColyseusAdapter.ts
+++ b/src/network/ColyseusAdapter.ts
@@ -17,6 +17,7 @@ export class ColyseusAdapter implements INetworkAdapter {
   private room!: Colyseus.Room;
   private model!: Model;
   private myPlayerId: string = '';
+  private _isSpectator: boolean = false;
 
   private turnResultCallback?: (result: TurnResult) => void;
   private playerJoinedCallback?: (playerId: string) => void;
@@ -38,11 +39,12 @@ export class ColyseusAdapter implements INetworkAdapter {
    * Connects to the Colyseus server and waits for player assignment.
    * Call this before passing the adapter to setupThree().
    */
-  async connect(roomId?: string): Promise<void> {
+  async connect(roomId?: string, spectate: boolean = false): Promise<void> {
+    const joinOptions = spectate ? { spectate: true } : {};
     if (roomId) {
-      this.room = await this.client.joinById(roomId);
+      this.room = await this.client.joinById(roomId, joinOptions);
     } else {
-      this.room = await this.client.joinOrCreate('game_room');
+      this.room = await this.client.joinOrCreate('game_room', joinOptions);
     }
 
     // Register all message handlers immediately after join, before awaiting anything.
@@ -80,9 +82,10 @@ export class ColyseusAdapter implements INetworkAdapter {
 
     // Forward future player arrivals to the joined callback.
     // Note: onAdd fires for every player including the local one during state sync.
-    // We skip the local player; the callback receives the playerId for remote players.
-    this.room.state.players.onAdd((_player: unknown, playerId: string) => {
+    // We skip the local player and any spectators; the callback receives the playerId for remote players.
+    this.room.state.players.onAdd((player: { isSpectator: boolean }, playerId: string) => {
       if (playerId === this.myPlayerId) return;
+      if (player.isSpectator) return;
       // player is the live PlayerState reference — changes will be reflected in it.
       // Delay one microtask so that initializePlayers() on the server has time to
       // push its state delta (nodeId, color) before we read them.
@@ -111,7 +114,8 @@ export class ColyseusAdapter implements INetworkAdapter {
         resolve();
       };
 
-      this.room.onMessage('player_assigned', (data: { playerId: string }) => {
+      this.room.onMessage('player_assigned', (data: { playerId: string; isSpectator: boolean }) => {
+        this._isSpectator = data.isSpectator;
         const assignedId = data.playerId;
         // Check if this player is already in the state (sync patch arrived first)
         if (this.room.state.players.has(assignedId)) {
@@ -155,11 +159,13 @@ export class ColyseusAdapter implements INetworkAdapter {
     }
 
     // Replace the local-play default players with the server's player set.
+    // Spectators are excluded from the model — they are observers only.
     this.model.players.clear();
     this.room.state.players.forEach((sp: {
       id: string; nodeId: number; angle: number; health: number;
-      isAlive: boolean; color: number;
+      isAlive: boolean; color: number; isSpectator: boolean;
     }, playerId: string) => {
+      if (sp.isSpectator) return;
       const startNode = this.model.nodeList[sp.nodeId];
       if (!startNode) return;
       const p = new Player(playerId, startNode, sp.color);
@@ -229,6 +235,8 @@ export class ColyseusAdapter implements INetworkAdapter {
   getRoom(): Colyseus.Room {
     return this.room;
   }
+
+  isSpectator(): boolean { return this._isSpectator; }
 
   supportsNPC(): boolean { return false; }
 

--- a/src/network/INetworkAdapter.ts
+++ b/src/network/INetworkAdapter.ts
@@ -11,6 +11,9 @@ export interface INetworkAdapter {
   /** Returns the player ID assigned to the local user */
   getMyPlayerId(): string;
 
+  /** Returns true if the local client joined as a spectator */
+  isSpectator(): boolean;
+
   /**
    * Initializes and returns the game Model.
    * LocalAdapter creates a fresh Model; ColyseusAdapter builds one from server state.

--- a/src/network/LocalAdapter.ts
+++ b/src/network/LocalAdapter.ts
@@ -113,6 +113,8 @@ export class LocalAdapter implements INetworkAdapter {
     }
   }
 
+  isSpectator(): boolean { return false; }
+
   supportsNPC(): boolean { return true; }
 
   /**

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -37,12 +37,20 @@ export class ThreeSetup {
 
     // Initialize game model via adapter
     const model = adapter.initializeModel();
+    const spectator = adapter.isSpectator();
+
+    // For spectators the assigned playerId is not in model.players;
+    // fall back to the first real player so the camera has a starting position.
+    const myPlayerId = adapter.getMyPlayerId();
+    const activePlayerId = model.players.has(myPlayerId)
+      ? myPlayerId
+      : (model.players.keys().next().value ?? myPlayerId);
 
     // Initialize visualization synchronization
     this.visualizationSync = new VisualizationSync(
       this.sceneManager,
       model,
-      adapter.getMyPlayerId(),
+      activePlayerId,
       this.eventBus,
     );
 
@@ -55,7 +63,7 @@ export class ThreeSetup {
       this.visualizationSync.getMeshToNodeMap(),
       this.eventBus,
       playerIds,
-      adapter.getMyPlayerId(),
+      activePlayerId,
     );
 
     // Keep InputHandler's active player in sync
@@ -67,8 +75,9 @@ export class ThreeSetup {
     this.gameController = new GameController(
       model,
       this.eventBus,
-      adapter.getMyPlayerId(),
-      adapter
+      activePlayerId,
+      adapter,
+      spectator,
     );
 
     // Re-apply obstacles + redraw if obstacles_ready arrives after initializeModel()

--- a/src/ui/GRF_main.tsx
+++ b/src/ui/GRF_main.tsx
@@ -8,7 +8,7 @@ import { LocalAdapter } from '../network/LocalAdapter';
 import { ColyseusAdapter } from '../network/ColyseusAdapter';
 import type { INetworkAdapter } from '../network/INetworkAdapter';
 
-type AppState = 'lobby' | 'connecting' | 'playing';
+type AppState = 'lobby' | 'connecting' | 'playing' | 'spectating';
 
 const GRF_main = () => {
   const [appState, setAppState] = React.useState<AppState>('lobby');
@@ -26,14 +26,14 @@ const GRF_main = () => {
     };
   }, [threeSetup]);
 
-  const startGame = React.useCallback(async (adapter: INetworkAdapter) => {
+  const startGame = React.useCallback(async (adapter: INetworkAdapter, isSpectator: boolean = false) => {
     const canvas = canvasRef.current;
     if (!canvas || initialized.current) return;
     initialized.current = true;
 
     const setup = setupThree(canvas, adapter);
     setThreeSetup(setup);
-    setAppState('playing');
+    setAppState(isSpectator ? 'spectating' : 'playing');
 
     // Online mode: when another player joins later, add them to the local model + scene.
     if (adapter instanceof ColyseusAdapter) {
@@ -62,20 +62,36 @@ const GRF_main = () => {
     }
   }, [startGame]);
 
+  const handleSpectate = React.useCallback(async (serverUrl: string) => {
+    setAppState('connecting');
+    setErrorMsg('');
+    try {
+      const adapter = new ColyseusAdapter(serverUrl);
+      await adapter.connect(undefined, true);
+      startGame(adapter, true);
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : '観戦接続に失敗しました');
+      setAppState('lobby');
+    }
+  }, [startGame]);
+
+  const inGame = appState === 'playing' || appState === 'spectating';
+
   return (
     <div>
       <canvas
         ref={canvasRef}
-        style={{ display: appState === 'playing' ? 'block' : 'none' }}
+        style={{ display: inGame ? 'block' : 'none' }}
       />
-      {appState === 'playing' && <GameHUD threeSetup={threeSetup} />}
-      {appState === 'playing' && <ConsoleLogger />}
-      {appState !== 'playing' && (
+      {inGame && <GameHUD threeSetup={threeSetup} isSpectator={appState === 'spectating'} />}
+      {inGame && <ConsoleLogger />}
+      {!inGame && (
         <LobbyUI
           connecting={appState === 'connecting'}
           errorMsg={errorMsg}
           onOffline={handleOffline}
           onOnline={handleOnline}
+          onSpectate={handleSpectate}
         />
       )}
     </div>

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -4,9 +4,10 @@ import { gameEventBus, GameEventType } from '../core/GameEventBus';
 
 interface GameHUDProps {
   threeSetup: ThreeSetup | null;
+  isSpectator?: boolean;
 }
 
-const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
+const GameHUD: React.FC<GameHUDProps> = ({ threeSetup, isSpectator = false }) => {
   const [gridVisible, setGridVisible] = React.useState(true);
   const [playerIds, setPlayerIds] = React.useState<string[]>([]);
   const [activeId, setActiveId] = React.useState<string>('');
@@ -62,8 +63,19 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     gap: '4px',
   };
 
+  const spectatorBannerStyle: React.CSSProperties = {
+    padding: '6px 14px',
+    backgroundColor: '#7B1FA2',
+    color: '#fff',
+    borderRadius: '4px',
+    fontSize: '13px',
+    fontWeight: 'bold',
+    letterSpacing: '2px',
+  };
+
   return (
     <div style={containerStyle}>
+      {isSpectator && <div style={spectatorBannerStyle}>SPECTATING</div>}
       <button
         onClick={handleToggleGrid}
         style={gridButtonStyle}

--- a/src/ui/LobbyUI.tsx
+++ b/src/ui/LobbyUI.tsx
@@ -5,9 +5,10 @@ interface LobbyUIProps {
   errorMsg: string;
   onOffline: () => void;
   onOnline: (serverUrl: string) => void;
+  onSpectate: (serverUrl: string) => void;
 }
 
-const LobbyUI: React.FC<LobbyUIProps> = ({ connecting, errorMsg, onOffline, onOnline }) => {
+const LobbyUI: React.FC<LobbyUIProps> = ({ connecting, errorMsg, onOffline, onOnline, onSpectate }) => {
   const [serverUrl, setServerUrl] = React.useState(
     import.meta.env.VITE_SERVER_URL ?? 'ws://localhost:2567'
   );
@@ -55,6 +56,13 @@ const LobbyUI: React.FC<LobbyUIProps> = ({ connecting, errorMsg, onOffline, onOn
     backgroundColor: '#2196F3',
     color: '#fff',
     minWidth: '160px',
+  };
+
+  const spectateButtonStyle: React.CSSProperties = {
+    ...buttonBase,
+    backgroundColor: '#7B1FA2',
+    color: '#fff',
+    minWidth: '120px',
   };
 
   const inputStyle: React.CSSProperties = {
@@ -116,6 +124,13 @@ const LobbyUI: React.FC<LobbyUIProps> = ({ connecting, errorMsg, onOffline, onOn
           disabled={connecting}
         >
           {connecting ? '接続中...' : 'オンライン接続'}
+        </button>
+        <button
+          style={spectateButtonStyle}
+          onClick={() => onSpectate(serverUrl)}
+          disabled={connecting}
+        >
+          {connecting ? '接続中...' : '観戦する'}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

- オンライン接続時にロビー画面の「観戦する」ボタン（紫）から観戦者として参加可能
- 観戦者はゲームロジック（開始条件・ターン処理・勝利判定）に一切影響を与えない
- ゲーム中途参加にも対応し、視点切り替えボタンで各プレイヤーの視点から観戦できる

## Changes

**Server**
- `PlayerState` に `isSpectator` フラグを追加（`@colyseus/schema` 差分同期対応）
- `GameRoom.onJoin` で `options.spectate` を受け取り、ゲーム開始条件を非観戦者のみでカウント
- `onLeave` / `countAlivePlayers` / `getAlivePlayerId` で観戦者を除外
- `handleTurnAction` で観戦者からのアクションを `SPECTATOR_CANNOT_ACT` エラーで拒否
- `ServerGameLogic.initializePlayers` で観戦者をスキップ

**Client**
- `INetworkAdapter` に `isSpectator(): boolean` を追加
- `ColyseusAdapter.connect(roomId?, spectate?)` に観戦フラグ引数を追加
- `initializeModel` / `onAdd` で観戦者を `model.players` から除外
- `GameController` が観戦者モード時は入力イベント（`NODE_CLICKED`, `CANVAS_CLICKED_EMPTY`）を購読しない
- `AppState` に `'spectating'` を追加、`GRF_main` に `handleSpectate` ハンドラーを追加
- `LobbyUI` に「観戦する」ボタンを追加
- `GameHUD` に `SPECTATING` バナーを表示

## Test plan

- [ ] サーバー起動: `cd server && npm run dev`
- [ ] フロントエンド起動: `npm run dev`
- [ ] ブラウザ2つで http://localhost:5173/2dFps/ を開き、1つを「オンライン接続」、もう1つを「観戦する」で参加
- [ ] 観戦者 HUD に `SPECTATING` バナーが表示される
- [ ] 観戦者がノードをクリックしても何も起きない
- [ ] 観戦者1人・プレイヤー0人では「ゲーム開始」しない（プレイヤー2人で開始）
- [ ] 観戦者の退出でゲームが終了しない
- [ ] プレイヤー切り替えボタンで視点変更できる
- [ ] ゲーム進行中に「観戦する」で途中参加しても現在の状態が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)