### PR TITLE
feat: プレイヤーメッシュ上に3D HPバーを追加

### DIFF
--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -290,6 +290,28 @@ export const RenderConfig = {
 } as const;
 
 /**
+ * HP bar (3D in-scene) configuration
+ */
+export const HPBarConfig = {
+  /** Bar width in world units */
+  Width: 24,
+  /** Bar height in world units */
+  Height: 3,
+  /** Z offset above the player mesh center */
+  ZOffset: 18,
+  /** Foreground color: human player = green */
+  ColorSelf: 0x00e676,
+  /** Foreground color: ally NPC = blue */
+  ColorAlly: 0x2196f3,
+  /** Foreground color: enemy = red */
+  ColorEnemy: 0xff1744,
+  /** Background (empty HP) color */
+  ColorBg: 0x333333,
+  /** HP change animation duration (seconds) */
+  AnimDuration: 0.4,
+} as const;
+
+/**
  * Lighting configuration
  */
 export const LightingConfig = {

--- a/src/rendering/HPBarManager.ts
+++ b/src/rendering/HPBarManager.ts
@@ -1,0 +1,81 @@
+import * as THREE from 'three';
+import { gsap } from 'gsap';
+import { HPBarConfig } from '../config/GameConfig';
+
+interface BarEntry {
+  fg: THREE.Mesh;
+  fgWidth: number;
+}
+
+/**
+ * Manages HP bar meshes attached as children of player group objects.
+ * Each bar consists of a background plane (gray) and a foreground plane (colored).
+ * The foreground plane's scale.x is animated by GSAP when HP changes.
+ *
+ * Coordinate note: parent groups have rotation.x = π/2 applied by VisualizationSync,
+ * so HP bar planes use rotation.x = -π/2 to face the camera.
+ * Foreground geometry is translated so its left edge is at x=0 (pivot at left),
+ * enabling scale.x reduction to shrink from the right.
+ */
+export class HPBarManager {
+  private bars = new Map<string, BarEntry>();
+
+  attachToPlayer(
+    playerObj: THREE.Object3D,
+    playerId: string,
+    isSelf: boolean,
+    isNPC: boolean,
+  ): void {
+    const w = HPBarConfig.Width;
+    const h = HPBarConfig.Height;
+
+    // Background bar (full width, gray)
+    const bgGeo = new THREE.PlaneGeometry(1, 1);
+    bgGeo.translate(0.5, 0, 0);
+    const bgMesh = new THREE.Mesh(
+      bgGeo,
+      new THREE.MeshBasicMaterial({ color: HPBarConfig.ColorBg }),
+    );
+    bgMesh.scale.set(w, h, 1);
+    bgMesh.rotation.x = -Math.PI / 2;
+    bgMesh.position.set(-w / 2, 0, HPBarConfig.ZOffset);
+    bgMesh.userData.fixedColor = true;
+    playerObj.add(bgMesh);
+
+    // Foreground bar (HP ratio, colored)
+    const fgColor = isSelf ? HPBarConfig.ColorSelf
+      : isNPC ? HPBarConfig.ColorEnemy
+      : HPBarConfig.ColorAlly;
+
+    const fgGeo = new THREE.PlaneGeometry(1, 1);
+    fgGeo.translate(0.5, 0, 0);
+    const fgMesh = new THREE.Mesh(
+      fgGeo,
+      new THREE.MeshBasicMaterial({ color: fgColor }),
+    );
+    fgMesh.scale.set(w, h, 1);
+    fgMesh.rotation.x = -Math.PI / 2;
+    // Slight Z offset so foreground renders above background
+    fgMesh.position.set(-w / 2, 0, HPBarConfig.ZOffset + 0.1);
+    fgMesh.userData.fixedColor = true;
+    playerObj.add(fgMesh);
+
+    this.bars.set(playerId, { fg: fgMesh, fgWidth: w });
+  }
+
+  update(playerId: string, health: number, maxHealth: number): void {
+    const entry = this.bars.get(playerId);
+    if (!entry) return;
+
+    const ratio = maxHealth > 0 ? Math.max(0, health / maxHealth) : 0;
+    gsap.to(entry.fg.scale, {
+      x: entry.fgWidth * ratio,
+      duration: HPBarConfig.AnimDuration,
+      ease: 'power2.out',
+    });
+  }
+
+  remove(playerId: string): void {
+    this.bars.delete(playerId);
+  }
+}

--- a/src/rendering/PlayerLifecycleManager.ts
+++ b/src/rendering/PlayerLifecycleManager.ts
@@ -6,6 +6,7 @@ import { PlayerAnimator } from './PlayerAnimator';
 import { createVariantPlayer } from './PlayerMeshFactory';
 import { AnimationConfig, RenderConfig } from '../config/GameConfig';
 import { PLAYER_CONSTANTS } from '../config/GameConfig';
+import { HPBarManager } from './HPBarManager';
 
 /**
  * Manages the lifecycle of player mesh objects:
@@ -19,6 +20,8 @@ export class PlayerLifecycleManager {
     private animator: PlayerAnimator,
     private model: Model,
     meshMap: Map<string, THREE.Object3D>,
+    private hpBarManager: HPBarManager,
+    private humanPlayerIds: Set<string>,
   ) {
     this.playerMeshes = meshMap;
   }
@@ -31,6 +34,8 @@ export class PlayerLifecycleManager {
       this.sceneManager.addToScene(obj);
       this.playerMeshes.set(playerId, obj);
       this.animator.startIdle(playerId);
+      const isSelf = this.humanPlayerIds.has(playerId);
+      this.hpBarManager.attachToPlayer(obj, playerId, isSelf, player.isNPC);
     }
   }
 
@@ -41,6 +46,14 @@ export class PlayerLifecycleManager {
     this.sceneManager.addToScene(obj);
     this.playerMeshes.set(playerId, obj);
     this.animator.startIdle(playerId);
+    const player = this.model.getPlayer(playerId);
+    const isSelf = this.humanPlayerIds.has(playerId);
+    this.hpBarManager.attachToPlayer(obj, playerId, isSelf, player?.isNPC ?? false);
+  }
+
+  updateHPBar(playerId: string): void {
+    const player = this.model.getPlayer(playerId);
+    if (player) this.hpBarManager.update(playerId, player.health, player.maxHealth);
   }
 
   // ── Visual effects ─────────────────────────────────────────────────────────

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -7,6 +7,7 @@ import { PlayerAnimator } from './PlayerAnimator';
 import { PlayerLifecycleManager } from './PlayerLifecycleManager';
 import { CameraFollowController } from './CameraFollowController';
 import { NodeVisualizationManager } from './NodeVisualizationManager';
+import { HPBarManager } from './HPBarManager';
 
 /**
  * Thin orchestrator: constructs the four specialized managers and wires them
@@ -17,6 +18,7 @@ export class VisualizationSync {
   private lifecycle: PlayerLifecycleManager;
   private animator:  PlayerAnimator;
   private camera:    CameraFollowController;
+  private hpBar:     HPBarManager;
   private model:     Model;
 
   private activePlayerId: string;
@@ -30,10 +32,17 @@ export class VisualizationSync {
     this.model = model;
     this.activePlayerId = activePlayerId;
 
+    const humanPlayerIds = new Set(
+      Array.from(model.players.entries())
+        .filter(([, p]) => !p.isNPC)
+        .map(([id]) => id),
+    );
+
     // Shared map — PlayerAnimator and PlayerLifecycleManager both reference it
     const meshMap = new Map<string, THREE.Object3D>();
     this.animator  = new PlayerAnimator(meshMap);
-    this.lifecycle = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap);
+    this.hpBar     = new HPBarManager();
+    this.lifecycle = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap, this.hpBar, humanPlayerIds);
     this.nodeVis   = new NodeVisualizationManager(sceneManager, model);
     this.camera    = new CameraFollowController(sceneManager);
 
@@ -113,6 +122,8 @@ export class VisualizationSync {
       if (isActive && moving) {
         this.camera.panTo(player.node.x, player.node.y, player.angle, CameraConfig.FollowMoveDuration, CameraConfig.FollowMoveEase);
       }
+
+      this.hpBar.update(playerId, player.health, player.maxHealth);
     }
   }
 
@@ -147,6 +158,7 @@ export class VisualizationSync {
 
     eventBus.on(GameEventType.VIS_SHOW_HIT_EFFECT, (data: { playerId: string }) => {
       this.lifecycle.showHitEffect(data.playerId);
+      this.lifecycle.updateHPBar(data.playerId);
     });
     eventBus.on(GameEventType.VIS_HIDE_PLAYER, (data: { playerId: string }) => {
       this.lifecycle.hidePlayer(data.playerId);


### PR DESCRIPTION
## Summary

- `HPBarConfig` を `GameConfig.ts` に追加（Width / Height / ZOffset / 色定数 / AnimDuration）
- `HPBarManager.ts` を新規作成：背景バー（グレー）＋前景バー（HP色）を `PlaneGeometry` で構成し、前景の `scale.x` を GSAP でアニメーション
- `PlayerLifecycleManager` に `HPBarManager` を統合し、プレイヤー生成時にバーをアタッチ
- `VisualizationSync` でターン処理後・被弾時に HP バーを更新

## 実装の詳細

HP バーはプレイヤー `THREE.Group` の子オブジェクトとして追加：
- 位置追従は自動（親の GSAP アニメーションに追従）
- フォグオブウォーの `setVisible` で親ごと隠れる
- 死亡時の `hidePlayer` フェードに自動巻き込まれる

色分け：自分（人間プレイヤー）= 緑 / NPC（敵）= 赤

## Test plan

- [ ] `npm run dev` でゲームを起動し、全プレイヤーの上に HP バーが表示されることを確認
- [ ] ショットを命中させ、被弾プレイヤーの HP バーが減少アニメーションすることを確認
- [ ] フォグオブウォー下で視野外プレイヤーが非表示になる際、HP バーも消えることを確認
- [ ] プレイヤー死亡時に HP バーがフェードアウトすることを確認

Close #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)