### PR TITLE
feat(rendering): FPS観戦モード・ダンスエフェクト・ビジュアル刷新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,12 @@ getPathToNode(fromNodeId: number, toNodeId: number, maxSteps: number): number[] 
 - `onAdd` は `initializePlayers` の状態デルタより先に発火する場合がある → `Promise.resolve()` で1マイクロタスク遅延
 - `MapSchema.forEach` の順序は保証されない → `playerOrder` 配列（挿入順）でターン管理
 
+## 座標系と角度規約
+
+ゲーム空間（model/logic 層）は **XY 平面、`player.angle` は度数法・`atan2(dy, dx)` ベース（0° = +X、反時計回り正）**。Three.js 側の座標変換、モデルローカル軸、`rotation.y` 変換式、過去の落とし穴は [`src/rendering/CLAUDE.md`](src/rendering/CLAUDE.md) に集約されている。
+
+`player.angle` は `getVisibleNodesAtAngle`、`NPCBrain`、`LocalAdapter` など model/logic 層全体で共有されているため、**レンダリング側の都合で変更してはいけない**。
+
 ## コーディング規約
 
 - **マジックナンバー禁止**: 数値定数は必ず `src/config/GameConfig.ts` に追加する

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -198,6 +198,34 @@ export const AnimationConfig = {
 } as const;
 
 /**
+ * Text burst effect configuration (dance victory effect)
+ */
+export const TextBurstEffectConfig = {
+  /** 飛来開始距離（world units） */
+  FlyInDistance: 600,
+  /** スプライトのワールドスケール */
+  SpriteWorldSize: 30,
+  /** 1文字あたりの着地半径基準値（world units）。文字数が増えると自動で拡大 */
+  LandRadiusPerChar: 30,
+  /** 支点の Y 位置オフセット（プレイヤー Y + これ） */
+  PivotYOffset: 10,
+  /** 1文字あたりの扇半角基準値（度）。文字数が増えると自動で拡大 */
+  FanHalfAngleDegPerChar: 20,
+  /** 飛び込みアニメ秒数 */
+  FlyInDuration: 0.35,
+  /** 扇開きアニメ秒数 */
+  FanOpenDuration: 0.25,
+  /** 表示維持秒数 */
+  HoldDuration: 1.2,
+  /** フェードアウト秒数 */
+  FadeOutDuration: 0.4,
+  /** 文字色 */
+  TextColor: '#ffdd00',
+  /** キャンバス1辺サイズ（px） */
+  CanvasSize: 128,
+} as const;
+
+/**
  * Camera configuration
  */
 export const CameraConfig = {

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -264,12 +264,14 @@ export const RenderConfig = {
   /** Player diamond marker size */
   PlayerMarkerSize: 20,
 
-  /** Y rotation offset applied to all player models so the face points forward (radians) */
+  /** Y rotation offset that aligns model's local +Z (forward) with world axes (radians).
+   *  Player rotation: rotation.y = -angle_rad + PlayerFacingOffset
+   *    where angle_rad is game angle (0° = +X, CCW positive), and gameToWorld maps game(x,y) → world(x,0,y).
+   *  At angle=0, rotation.y = π/2 turns local +Z to world +X (game +X). */
   PlayerFacingOffset: Math.PI / 2,
 
-  /** Z offset applied to player mesh groups to vertically center the Scout model over the node circle.
-   *  After rotation.x = π/2, local Y maps to world Z. The model's visual center is below Y=0,
-   *  so we lift by HS * 0.7 (HS = PlayerMarkerSize / 6.4). */
+  /** Y offset applied to player mesh groups to vertically center the Scout model over the node circle.
+   *  The model's visual center is below Y=0, so we lift by HS * 3.21 (HS = PlayerMarkerSize / 6.4). */
   PlayerZOffset: (20 / 6.4) * 3.21,
 
   // --- Player body material ---

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -519,8 +519,32 @@ export const HUMAN_PLAYER_ID = ENTITY_IDS.PLAYER_1;
  * Keyboard key constants for game controls
  */
 export const KEYBOARD_KEYS = {
-  DANCE: 'd',
-  DANCE_UPPER: 'D',
+  DANCE: 'f',
+  DANCE_UPPER: 'F',
+  SPECTATOR_TOGGLE: 't',
+  SPECTATOR_TOGGLE_UPPER: 'T',
+} as const;
+
+/**
+ * FPS spectator mode parameters.
+ * 観戦モードは T キーで通常追従カメラと FPS フリーカメラを切り替える。
+ * 移動・視点・感度などすべてここで一元管理する。
+ */
+export const FPSConfig = {
+  /** 水平移動速度（world units / sec） */
+  MoveSpeed: 200,
+  /** Shift 押下時の速度乗数 */
+  SprintMultiplier: 2,
+  /** マウス感度（度 / pixel） */
+  MouseSensitivity: 0.15,
+  /** 観戦カメラの初期目線高さ（world Y、プレイヤー頭部相当） */
+  EyeHeight: 12,
+  /** ピッチ制限（度、上下対称）。±90° に近づくとジンバルロックするため少し内側に */
+  PitchLimit: 85,
+  /** FPS モード時の FOV（通常 90° → 75° に狭めて没入感を出す） */
+  FOV: 75,
+  /** dt のクランプ上限（秒）。タブ復帰時の巨大 dt で吹き飛ぶのを防ぐ */
+  MaxDeltaSeconds: 0.1,
 } as const;
 
 /**

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -223,6 +223,20 @@ export const TextBurstEffectConfig = {
   TextColor: '#ffdd00',
   /** キャンバス1辺サイズ（px） */
   CanvasSize: 128,
+
+  // --- ダンスバースト ---
+  /** ダンス中の発射回数 */
+  DanceBurstCount: 6,
+  /** 発射間隔（ms） */
+  DanceBurstIntervalMs: 150,
+  /** バーストで使用する文字 */
+  DanceBurstChars: ['ダ', 'ン', 'ス'] as string[],
+  /** 飛び出し半径（world units） */
+  DanceBurstFlyRadius: 60,
+  /** 飛び出し＋フェードアウト秒数 */
+  DanceBurstDuration: 0.4,
+  /** バーストスプライトのワールドスケール */
+  DanceBurstSpriteSize: 25,
 } as const;
 
 /**

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -66,23 +66,23 @@ export const NodeConfig = {
   /** Number of segments in circle geometry */
   CircleSegments: 100,
 
-  /** Default node color (dark tactical green) */
-  DefaultColor: 0x1a3a2a,
+  /** Default node color (charcoal) */
+  DefaultColor: 0x1c1c1c,
 
-  /** Visible node color (bright cyan) */
-  VisibleColor: 0x00e5cc,
+  /** Visible node color (muted gold) */
+  VisibleColor: 0xc8a96e,
 
-  /** Selected node color (dark orange) */
-  SelectedColor: 0xff8c00,
+  /** Selected node color (copper) */
+  SelectedColor: 0xb87333,
 
-  /** Next move node color (neon green) */
-  NextMoveColor: 0x39ff14,
+  /** Next move node color (sage green) */
+  NextMoveColor: 0x8fbc8f,
 
-  /** Shot target node color (red) */
-  ShotTargetColor: 0xff2020,
+  /** Shot target node color (dark red) */
+  ShotTargetColor: 0xc0392b,
 
-  /** Reachable node color (soft teal) */
-  ReachableColor: 0x2a7a6a,
+  /** Reachable node color (dark grey) */
+  ReachableColor: 0x3d3d3d,
 } as const;
 
 
@@ -252,11 +252,11 @@ export const CameraConfig = {
  * Render / visual theme configuration
  */
 export const RenderConfig = {
-  /** Background clear color (very dark navy) */
-  BackgroundColor: 0x050d12,
+  /** Background clear color (near black) */
+  BackgroundColor: 0x0a0a0a,
 
   /** Grid line color for background grid */
-  GridLineColor: 0x0d2b20,
+  GridLineColor: 0x1a1a1a,
 
   /** Grid line opacity */
   GridLineOpacity: 0.6,
@@ -279,6 +279,10 @@ export const RenderConfig = {
   PlayerBodyMetalness: 0.3,
 
   // --- Humanoid variant: handgun ---
+  /** Default player color when none is specified */
+  PlayerDefaultColor: 0xffff00,
+  /** Player color during hit effect */
+  PlayerHitColor: 0xff0000,
   /** Handgun barrel color (dark metallic) */
   PlayerGunBarrelColor: 0x222233,
 
@@ -294,31 +298,21 @@ export const RenderConfig = {
  */
 export const LightingConfig = {
   /** Ambient light intensity */
-  AmbientIntensity: 0.3,
+  AmbientIntensity: 0.8,
   /** Hemisphere light sky color */
-  HemisphereSkyColor: 0x223344,
+  HemisphereSkyColor: 0x1a1510,
   /** Hemisphere light ground color */
-  HemisphereGroundColor: 0x0d2b20,
+  HemisphereGroundColor: 0x0d0b08,
   /** Hemisphere light intensity */
-  HemisphereIntensity: 0.7,
+  HemisphereIntensity: 1.2,
   /** Main directional light intensity */
-  DirectionalIntensity: 1.2,
-  /** Main directional light X position */
-  DirectionalX: 30,
-  /** Main directional light Y position */
+  DirectionalIntensity: 2.0,
+  /** Main directional light Y height (fixed during orbit) */
   DirectionalY: 20,
-  /** Main directional light Z position */
-  DirectionalZ: 100,
-  /** Rim light color (cool blue) */
-  RimLightColor: 0x4488cc,
-  /** Rim light intensity */
-  RimLightIntensity: 0.4,
-  /** Rim light X position */
-  RimLightX: -50,
-  /** Rim light Y position */
-  RimLightY: -50,
-  /** Rim light Z position */
-  RimLightZ: 60,
+  /** Orbit radius of directional light in XZ plane */
+  DirectionalOrbitRadius: 10,
+  /** Orbit speed of directional light (radians per second) */
+  DirectionalOrbitSpeed: 0.3,
 } as const;
 
 /**
@@ -331,14 +325,14 @@ export const WallConfig = {
   ZOffset: 0,
   /** Wall depth (screen-width of the wall slab) */
   Depth: 4,
-  /** Wall color (dark tactical blue-grey) */
-  Color: 0x1a2e38,
+  /** Wall color (dark brown) */
+  Color: 0x2a2420,
   /** PBR roughness for walls */
   Roughness: 0.85,
   /** PBR metalness for walls */
   Metalness: 0.05,
   /** Emissive color for walls */
-  EmissiveColor: 0x0a1520,
+  EmissiveColor: 0x100e0c,
   /** Emissive intensity for walls */
   EmissiveIntensity: 0.15,
   /** userData key used to identify wall meshes during scene traversal */
@@ -374,11 +368,39 @@ export const PostProcessConfig = {
   /** Enable bloom post-processing */
   EnableBloom: true,
   /** Bloom effect strength */
-  BloomStrength: 0.4,
+  BloomStrength: 0.8,
   /** Bloom effect radius */
-  BloomRadius: 0.3,
+  BloomRadius: 0.5,
   /** Bloom threshold (only pixels brighter than this bloom) */
-  BloomThreshold: 0.35,
+  BloomThreshold: 0.2,
+} as const;
+
+/**
+ * Shadow configuration
+ */
+export const ShadowConfig = {
+  /** Enable shadow maps */
+  Enabled: true,
+  /** Shadow map size (higher = sharper, more expensive) */
+  MapSize: 2048,
+  /** Shadow camera near clip */
+  CameraNear: 1,
+  /** Shadow camera far clip */
+  CameraFar: 2000,
+  /** Shadow camera orthographic half-size */
+  CameraSize: 800,
+} as const;
+
+/**
+ * Fog configuration
+ */
+export const FogConfig = {
+  /** Enable exponential fog */
+  Enabled: true,
+  /** Fog color (matches background) */
+  Color: 0x0a0a0a,
+  /** Fog density (higher = thicker) */
+  Density: 0.0008,
 } as const;
 
 /**

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -56,6 +56,10 @@ export enum GameEventType {
   NPC_TURNS_COMPLETE = 'npc:turns_complete',
   INPUT_LOCKED = 'input:locked',
 
+  // Spectator (FPS) mode events
+  FPS_MODE_TOGGLE_REQUESTED = 'fps:toggle_requested',
+  FPS_MODE_CHANGED = 'fps:mode_changed',
+
   // Network events (Phase 2+: used by ColyseusAdapter)
   NETWORK_CONNECTED = 'network:connected',
   NETWORK_DISCONNECTED = 'network:disconnected',
@@ -170,6 +174,12 @@ export interface GameEventData {
   [GameEventType.NPC_TURNS_COMPLETE]: void;
   [GameEventType.INPUT_LOCKED]: {
     locked: boolean;
+  };
+
+  // Spectator (FPS) mode events
+  [GameEventType.FPS_MODE_TOGGLE_REQUESTED]: void;
+  [GameEventType.FPS_MODE_CHANGED]: {
+    enabled: boolean;
   };
 
   // Network events

--- a/src/input/InputHandler.ts
+++ b/src/input/InputHandler.ts
@@ -16,6 +16,7 @@ export class InputHandler {
   private eventBus: GameEventBus;
   private playerIds: string[];
   private activePlayerId: string;
+  private fpsActive = false;
   private readonly handleCanvasClickBound: (e: MouseEvent) => void;
   private readonly handleKeyDownBound: (e: KeyboardEvent) => void;
 
@@ -40,6 +41,11 @@ export class InputHandler {
     this.handleKeyDownBound = this.handleKeyDown.bind(this);
 
     this.setupEventListeners();
+
+    // FPS 観戦モード中はゲーム操作を全て無効化する
+    this.eventBus.on(GameEventType.FPS_MODE_CHANGED, (data: { enabled: boolean }) => {
+      this.fpsActive = data.enabled;
+    });
   }
 
   /** Updates the active player ID (call when the active player changes). */
@@ -59,6 +65,7 @@ export class InputHandler {
    * Handles canvas click events
    */
   private handleCanvasClick(event: MouseEvent): void {
+    if (this.fpsActive) return;
     const intersects = this.getIntersects(event);
 
     if (intersects.length > 0) {
@@ -80,15 +87,26 @@ export class InputHandler {
    * Handles keyboard events
    */
   private handleKeyDown(event: KeyboardEvent): void {
+    // T キーは FPS モードのトグルのため常時受け付ける（FPS 中の退出用も同経路）
+    if (event.key === KEYBOARD_KEYS.SPECTATOR_TOGGLE ||
+        event.key === KEYBOARD_KEYS.SPECTATOR_TOGGLE_UPPER) {
+      this.eventBus.emit(GameEventType.FPS_MODE_TOGGLE_REQUESTED);
+      return;
+    }
+
+    // F キー（ダンス）は観戦モード中も発火させる
+    if (event.key === KEYBOARD_KEYS.DANCE ||
+        event.key === KEYBOARD_KEYS.DANCE_UPPER) {
+      this.eventBus.emit(GameEventType.VIS_PLAY_DANCE, { playerId: this.activePlayerId });
+      return;
+    }
+
+    if (this.fpsActive) return;
+
     this.eventBus.emit(GameEventType.KEY_PRESSED, { key: event.key });
 
-    // Handle dance animation
-    if (event.key === KEYBOARD_KEYS.DANCE ||
-             event.key === KEYBOARD_KEYS.DANCE_UPPER) {
-      this.eventBus.emit(GameEventType.VIS_PLAY_DANCE, { playerId: this.activePlayerId });
-    }
     // Handle dynamic player selection (keys 1-9)
-    else if (event.key >= '1' && event.key <= '9') {
+    if (event.key >= '1' && event.key <= '9') {
       const keyNumber = parseInt(event.key, 10);
       const playerIndex = keyNumber - 1;
 

--- a/src/rendering/CLAUDE.md
+++ b/src/rendering/CLAUDE.md
@@ -1,0 +1,137 @@
+# CLAUDE.md — `src/rendering/`
+
+ルートの [CLAUDE.md](../../CLAUDE.md) を読んだ前提で、本ディレクトリ固有の設計を補足する。座標系・角度規約はルートの「座標系と角度規約」を必ず参照すること。
+
+## 役割
+
+Three.js による WebGL 描画を担う。**model/logic 層を直接参照しない**: 描画は `GameEventBus` の `VIS_*` イベントを購読して反応するだけで、ゲーム状態の書き換えは行わない（読み取り専用で `Model` を参照する）。
+
+## ファイル一覧と責務
+
+| ファイル | 行数 | 責務 |
+|---|---:|---|
+| [threeSetup.ts](threeSetup.ts) | 153 | エントリポイント。`SceneManager` / `VisualizationSync` / `InputHandler` / `GameController` を構築・配線し、レンダーループを開始 |
+| [SceneManager.ts](SceneManager.ts) | 293 | `WebGLRenderer` / `Scene` / `PerspectiveCamera` / `OrbitControls` / `EffectComposer`(Bloom) / Fog / 影 / ライティング / 背景グリッドを構築・保持。`addToScene` / `removeFromScene` を提供 |
+| [VisualizationSync.ts](VisualizationSync.ts) | 170 | **薄いオーケストレーター**。`VIS_*` イベントを購読し、4つの専門マネージャに委譲する |
+| [PlayerLifecycleManager.ts](PlayerLifecycleManager.ts) | 155 | プレイヤーメッシュの生成・破棄、`applyTransform`（位置・回転・スケール）、ヒット/被弾エフェクト |
+| [PlayerAnimator.ts](PlayerAnimator.ts) | 200 | GSAP を使った `idle` / `walk` / `attack` / `dance` のボディアニメーション。`userData.partNames` で部位を解決 |
+| [PlayerMeshFactory.ts](PlayerMeshFactory.ts) | 231 | Scout（人型）プレイヤーの 3D メッシュを構築。`createVariantPlayer(color)` を公開 |
+| [NodeVisualizationManager.ts](NodeVisualizationManager.ts) | 209 | ノード円・壁メッシュの生成・破棄、`meshToNodeMap` / `nodeToMeshMap` の双方向 ID マップ、ノード色の差分更新 |
+| [NodeWallMeshFactory.ts](NodeWallMeshFactory.ts) | 51 | `createNodeCircle(x, y)`、`createWallMesh(x1, y1, x2, y2)` のステートレスファクトリ |
+| [CameraFollowController.ts](CameraFollowController.ts) | 59 | カメラのプレイヤー追従（`snapTo` 即時 / `panTo` GSAP 補間）。プレイヤーの後方に配置 |
+| [MeshUtils.ts](MeshUtils.ts) | 31 | `gameToWorld(gx, gy, height?)`、`createUndefinedMesh()`、`setNodeColor()` のユーティリティ |
+
+## アーキテクチャ
+
+```
+threeSetup.ts (entry)
+├── SceneManager                          ← Three.js 基盤
+└── VisualizationSync (orchestrator)
+    ├── PlayerLifecycleManager            ← メッシュのライフサイクル
+    │   └─ uses → PlayerMeshFactory       ← メッシュ構築（ステートレス）
+    ├── PlayerAnimator                    ← GSAP アニメ（meshMap を共有）
+    ├── NodeVisualizationManager          ← ノード/壁
+    │   └─ uses → NodeWallMeshFactory     ← メッシュ構築（ステートレス）
+    └── CameraFollowController            ← カメラ追従
+```
+
+`VisualizationSync` と `PlayerLifecycleManager` / `PlayerAnimator` は **同じ `meshMap: Map<string, THREE.Object3D>`** を共有することで、アニメーションとライフサイクル操作の両方が同一メッシュを参照できる（[VisualizationSync.ts:34-36](VisualizationSync.ts#L34-L36)）。
+
+## イベント駆動の購読
+
+`VisualizationSync` が `GameEventBus` から購読する `VIS_*` イベント:
+
+| イベント | 委譲先 |
+|---|---|
+| `VIS_UPDATE_VIEW` | 全マネージャ（位置・色・カメラの全更新） |
+| `VIS_SET_ACTIVE_PLAYER` | `CameraFollowController.panTo` |
+| `VIS_SHOW_HIT_EFFECT` | `PlayerLifecycleManager.showHitEffect` |
+| `VIS_PLAYER_DEATH` / `VIS_PLAYER_REVIVE` | `PlayerLifecycleManager` |
+| `VIS_NODE_*`（select/next/shot のハイライト） | `NodeVisualizationManager` |
+| `OBSTACLES_UPDATED` | `NodeVisualizationManager.rebuildWalls` |
+
+`GameController`（logic 層）はこれらのイベントを発火するだけで、`VisualizationSync` を直接参照しない（レイヤー違反を避けるため、ルート CLAUDE.md「レイヤー違反修正」を参照）。
+
+## 座標系と角度規約
+
+ゲームロジックと Three.js の描画では座標系が異なる。回転や向きを扱うコードを書くときは以下を守ること。
+
+### 3つの座標空間
+
+| 空間 | 軸の意味 |
+|---|---|
+| **Game**（model/logic 層） | XY 平面。+X = 右、+Y = 上 |
+| **Three.js World**（rendering 層） | XZ 平面に展開。+X = 右、+Z = game の +Y 方向、+Y = 高さ（上空） |
+| **Player Model ローカル** | +Z = 前方、+X = 右、+Y = 上 |
+
+写像は [`gameToWorld(gx, gy, height) → (gx, height, gy)`](MeshUtils.ts#L8-L10) **のみ** で行う。他の場所で座標を直接いじらない。
+
+### 角度規約（ゲーム空間）
+
+`player.angle` は度数法、`Math.atan2(dy, dx) * 180/π` で算出（[`model.ts`](../model/model.ts) の `getAngleBetweenNodes`）。
+
+- `0°` = game の **+X 方向（右）**
+- `90°` = game の **+Y 方向**
+- 反時計回りが正
+
+この規約は model / logic 層全体（`getVisibleNodesAtAngle`、`NPCBrain`、`LocalAdapter` など）で共有されているため、**レンダリング側の都合で変更してはいけない**。
+
+### モデルローカル軸（PlayerMeshFactory）
+
+[`PlayerMeshFactory.createVariantPlayer`](PlayerMeshFactory.ts) で構築されるプレイヤーメッシュは、**ローカル +Z = 前方** に統一されている。各部位もこの規約で組み立てること（足のつま先・銃身ともに +Z 方向）。
+
+### 角度→ rotation.y 変換式（rendering 層）
+
+[`PlayerLifecycleManager.applyTransform`](PlayerLifecycleManager.ts) でのみ適用：
+
+```typescript
+obj.rotation.y = -(angle * Math.PI / 180) + RenderConfig.PlayerFacingOffset;
+// PlayerFacingOffset = Math.PI / 2
+```
+
+導出: モデル前方 +Z を game angle θ° の方向 `(cosθ, 0, sinθ)` に向けるには `rotation.y = atan2(cosθ, sinθ) = π/2 − θ_rad`。`PlayerFacingOffset = π/2` はこの「モデル前方 +Z を world +X に合わせる」初期オフセットを表す。
+
+### 過去の落とし穴
+
+- コミット 67b3474（XY→XZ 平面変換導入）時、`rotation.x = π/2` が削除されたが、`PlayerMeshFactory.buildGearGun` で銃身がローカル +Y を前方として作られていたため、銃身が空を向く不整合が残っていた → 銃身に `rotation.x = π/2` を追加してローカル +Z を前方に統一済み。
+- 同コミット直後は `rotation.y = -((angle + offset))` と外側括弧で全項を反転していたため、結果が常に 180° ずれていた → `rotation.y = -angle + offset` に修正済み。
+
+## 設定の参照先
+
+すべての数値定数は [`src/config/GameConfig.ts`](../config/GameConfig.ts) に集約：
+
+- `RenderConfig` — マテリアル・色・サイズ・PlayerFacingOffset
+- `CameraConfig` — FOV / 距離 / 追従速度・イージング
+- `ShadowConfig` / `FogConfig` / `PostProcessConfig` / `LightingConfig` — シーン演出
+- `AnimationConfig` — GSAP duration / イージング
+- `NodeConfig` / `NodeVisualConfig` / `WallConfig` / `MapConfig` — ノード・壁・グリッド
+- `PlayerConfig` — Fog of War 等のゲームプレイ寄り定数
+
+**マジックナンバー禁止**。新しい定数は必ず `GameConfig.ts` に追加してから参照する。
+
+## 描画パイプラインの順序
+
+レンダーループ ([threeSetup.ts:92-98](threeSetup.ts#L92-L98)):
+
+```
+requestAnimationFrame
+  → SceneManager.render()
+      → tickCallbacks（OrbitControls.update など）
+      → composer ? composer.render() : renderer.render(scene, camera)
+```
+
+GSAP アニメーションは独立した内部タイマーで mesh の `position` / `rotation` / `material` プロパティを更新するため、レンダーループは「現在の状態を毎フレーム描く」だけでよい。
+
+## よくある落とし穴
+
+- **メッシュ ID とノード ID は別物**: `THREE.Mesh.id` はランタイム自動採番、`Node.id` は model 層の意味的 ID。Raycaster の結果から Node を引くには `meshToNodeMap`（[NodeVisualizationManager.ts:21-22](NodeVisualizationManager.ts#L21-L22)）を経由する。
+- **GSAP の重複実行**: 同じプロパティに連続で `gsap.to` を呼ぶとアニメーションが累積する。`PlayerAnimator.killAll(playerId)` で前のトゥイーンを止めてから新規開始する規約。
+- **影の有効化**: `ShadowConfig.Enabled` が true のとき、各メッシュで `castShadow` / `receiveShadow` を明示的にセットしないと影が出ない（[PlayerMeshFactory.ts:220-227](PlayerMeshFactory.ts#L220-L227)、[NodeWallMeshFactory.ts:21,47-48](NodeWallMeshFactory.ts#L21)）。
+- **ファクトリは状態を持たない**: `PlayerMeshFactory` / `NodeWallMeshFactory` は純粋関数の集合。状態は `*Manager` 側で持つ。
+- **logic/model を直接 import しない**: 描画コードから `GameController` や `StateMachine` を呼ばない。必要なら `Model`（読み取り専用）か `GameEventBus` 経由にする。
+
+## デバッグ補助
+
+- [SceneManager.ts:66](SceneManager.ts#L66): シーン原点に `AxesHelper`（赤=+X、緑=+Y、青=+Z）を表示
+- [PlayerMeshFactory.ts:216](PlayerMeshFactory.ts#L216): 各プレイヤーモデルに `AxesHelper` を表示（モデルローカル軸の可視化）
+- 向きが疑わしいときは AxesHelper の青矢印（+Z = モデル前方）が進行方向を指しているかを目視確認するのが最速。

--- a/src/rendering/CameraFollowController.ts
+++ b/src/rendering/CameraFollowController.ts
@@ -1,6 +1,7 @@
 import { gsap } from 'gsap';
 import { CameraConfig } from '../config/GameConfig';
 import type { SceneManager } from './SceneManager';
+import { gameToWorld } from './MeshUtils';
 
 /**
  * Manages camera follow behaviour: smooth pan animations and instant snap.
@@ -10,45 +11,47 @@ export class CameraFollowController {
 
   constructor(private sceneManager: SceneManager) {}
 
-  /** Compute XY camera offset from player angle (degrees) so camera sits behind the player. */
-  private calcOffset(angle: number): { ox: number; oy: number } {
+  /** Compute XZ camera offset from player angle (degrees) so camera sits behind the player. */
+  private calcOffset(angle: number): { ox: number; oz: number } {
     const rad = angle * Math.PI / 180;
     return {
       ox: -Math.cos(rad) * CameraConfig.BackDistance,
-      oy: -Math.sin(rad) * CameraConfig.BackDistance,
+      oz: -Math.sin(rad) * CameraConfig.BackDistance,
     };
   }
 
-  /** Immediately position the camera behind (x, y) facing angle, with no animation. */
-  snapTo(x: number, y: number, angle: number): void {
+  /** Immediately position the camera behind (gx, gy) facing angle, with no animation. */
+  snapTo(gx: number, gy: number, angle: number): void {
     const camera = this.sceneManager.getCamera();
-    const { ox, oy } = this.calcOffset(angle);
-    camera.up.set(0, 0, 1);
-    camera.position.set(x + ox, y + oy, CameraConfig.OffsetZ);
-    camera.lookAt(x, y, 0);
+    const { ox, oz } = this.calcOffset(angle);
+    const target = gameToWorld(gx, gy);
+    camera.up.set(0, 1, 0);
+    camera.position.set(target.x + ox, CameraConfig.OffsetZ, target.z + oz);
+    camera.lookAt(target);
   }
 
   /**
-   * Smoothly pan the camera behind (x, y) facing angle.
+   * Smoothly pan the camera behind (gx, gy) facing angle.
    * Animates camera.position and calls lookAt each frame via onUpdate.
    */
-  panTo(x: number, y: number, angle: number, duration: number, ease: string): void {
+  panTo(gx: number, gy: number, angle: number, duration: number, ease: string): void {
     if (this.followTimeline) {
       this.followTimeline.kill();
     }
 
     const camera = this.sceneManager.getCamera();
-    camera.up.set(0, 0, 1);
-    const { ox, oy } = this.calcOffset(angle);
+    camera.up.set(0, 1, 0);
+    const { ox, oz } = this.calcOffset(angle);
+    const target = gameToWorld(gx, gy);
 
     const tl = gsap.timeline({ onComplete: () => { this.followTimeline = null; } });
     tl.to(camera.position, {
-      x: x + ox,
-      y: y + oy,
-      z: CameraConfig.OffsetZ,
+      x: target.x + ox,
+      y: CameraConfig.OffsetZ,
+      z: target.z + oz,
       duration,
       ease,
-      onUpdate: () => camera.lookAt(x, y, 0),
+      onUpdate: () => camera.lookAt(target),
     }, 0);
 
     this.followTimeline = tl;

--- a/src/rendering/FPSCameraController.ts
+++ b/src/rendering/FPSCameraController.ts
@@ -1,0 +1,272 @@
+import * as THREE from 'three';
+import type { OrbitControls } from 'three-stdlib';
+import { SceneManager } from './SceneManager';
+import { CameraFollowController } from './CameraFollowController';
+import { GameEventBus, GameEventType } from '../core/GameEventBus';
+import type { Model } from '../model/model';
+import { CameraConfig, FPSConfig } from '../config/GameConfig';
+import { gameToWorld } from './MeshUtils';
+
+/**
+ * FPS 観戦モードのカメラ制御。
+ * - WASD で水平移動、Space/Ctrl で上下、Shift で加速
+ * - Pointer Lock + mousemove で yaw/pitch
+ * - enable/disable は GameEventBus 経由で外部から呼ばれる
+ *
+ * model/logic 層には触れず、Model は読み取り専用で active player の位置取得にのみ使用する。
+ */
+export class FPSCameraController {
+  private camera: THREE.PerspectiveCamera;
+  private canvas: HTMLCanvasElement;
+  private sceneManager: SceneManager;
+  private follow: CameraFollowController;
+  private eventBus: GameEventBus;
+  private model: Model;
+  private getActivePlayerId: () => string;
+
+  private enabled = false;
+  private yaw = 0;    // degrees, ゲーム空間規約 (0°=+X, CCW 正)
+  private pitch = 0;  // degrees, +が上
+  private prevTime = 0;
+
+  private keys = { w: false, a: false, s: false, d: false, space: false, ctrl: false, shift: false };
+
+  // 通常モード復帰用にカメラ状態を退避
+  private savedFov: number = CameraConfig.FOV;
+  private savedOrbitEnabled = false;
+
+  // バインド済みリスナ（dispose で解除するため保持）
+  private readonly onCanvasClick: (e: MouseEvent) => void;
+  private readonly onMouseMove: (e: MouseEvent) => void;
+  private readonly onKeyDown: (e: KeyboardEvent) => void;
+  private readonly onKeyUp: (e: KeyboardEvent) => void;
+  private readonly onPointerLockChange: () => void;
+  private readonly tickBound: () => void;
+
+  constructor(
+    camera: THREE.PerspectiveCamera,
+    canvas: HTMLCanvasElement,
+    sceneManager: SceneManager,
+    follow: CameraFollowController,
+    eventBus: GameEventBus,
+    model: Model,
+    getActivePlayerId: () => string,
+  ) {
+    this.camera = camera;
+    this.canvas = canvas;
+    this.sceneManager = sceneManager;
+    this.follow = follow;
+    this.eventBus = eventBus;
+    this.model = model;
+    this.getActivePlayerId = getActivePlayerId;
+
+    this.onCanvasClick = this.handleCanvasClick.bind(this);
+    this.onMouseMove = this.handleMouseMove.bind(this);
+    this.onKeyDown = this.handleKeyDown.bind(this);
+    this.onKeyUp = this.handleKeyUp.bind(this);
+    this.onPointerLockChange = this.handlePointerLockChange.bind(this);
+    this.tickBound = this.tick.bind(this);
+
+    // モード解除時にOSがPointer Lockを外したら自動で disable
+    document.addEventListener('pointerlockchange', this.onPointerLockChange);
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** FPS モードに入る。アクティブプレイヤーの目線へカメラを配置し、Pointer Lock を要求する。 */
+  enable(): void {
+    if (this.enabled) return;
+
+    const activeId = this.getActivePlayerId();
+    const player = this.model.getPlayer(activeId);
+    if (!player) {
+      console.warn('[FPSCameraController] enable() called but no active player available');
+      return;
+    }
+
+    // 既存追従アニメーションを止める意味で snapTo は呼ばない（カメラ位置を直接設定）
+    this.savedFov = this.camera.fov;
+    const orbit = this.sceneManager.getControls() as OrbitControls;
+    this.savedOrbitEnabled = orbit.enabled;
+    orbit.enabled = false;
+
+    const w = gameToWorld(player.node.x, player.node.y);
+    this.camera.position.set(w.x, FPSConfig.EyeHeight, w.z);
+    this.yaw = player.angle;
+    this.pitch = 0;
+    this.applyLook();
+
+    this.camera.fov = FPSConfig.FOV;
+    this.camera.updateProjectionMatrix();
+
+    // 入力リスナ登録
+    this.canvas.addEventListener('click', this.onCanvasClick);
+    document.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('keyup', this.onKeyUp);
+
+    this.prevTime = performance.now();
+    this.sceneManager.addTickCallback(this.tickBound);
+
+    this.enabled = true;
+    this.eventBus.emit(GameEventType.FPS_MODE_CHANGED, { enabled: true });
+
+    // Pointer Lock 要求（ユーザージェスチャ起源で呼ばれる前提：T キー押下からの emit 経由）
+    this.requestPointerLock();
+  }
+
+  /** 通常モードに戻す。カメラは現在のアクティブプレイヤーの追従位置にスナップ。 */
+  disable(): void {
+    if (!this.enabled) return;
+
+    this.sceneManager.removeTickCallback(this.tickBound);
+    this.canvas.removeEventListener('click', this.onCanvasClick);
+    document.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('keyup', this.onKeyUp);
+
+    // 押下フラグを全リセット（FPS 中の押しっぱなしが漏れないように）
+    this.keys.w = this.keys.a = this.keys.s = this.keys.d = false;
+    this.keys.space = this.keys.ctrl = this.keys.shift = false;
+
+    if (document.pointerLockElement === this.canvas) {
+      document.exitPointerLock();
+    }
+
+    // FOV 復元
+    this.camera.fov = this.savedFov;
+    this.camera.updateProjectionMatrix();
+
+    // OrbitControls を元に戻す
+    const orbit = this.sceneManager.getControls() as OrbitControls;
+    orbit.enabled = this.savedOrbitEnabled;
+
+    // アクティブプレイヤーへスナップ（パン中で取り残されたカメラを定位置に戻す）
+    const activeId = this.getActivePlayerId();
+    const player = this.model.getPlayer(activeId);
+    if (player) {
+      this.follow.snapTo(player.node.x, player.node.y, player.angle);
+    }
+
+    this.enabled = false;
+    this.eventBus.emit(GameEventType.FPS_MODE_CHANGED, { enabled: false });
+  }
+
+  dispose(): void {
+    if (this.enabled) this.disable();
+    document.removeEventListener('pointerlockchange', this.onPointerLockChange);
+  }
+
+  // ── private ──────────────────────────────────────────────────────────
+
+  private requestPointerLock(): void {
+    // ブラウザによっては Promise を返す。失敗しても致命的ではないので握りつぶす。
+    const req = this.canvas.requestPointerLock();
+    if (req && typeof (req as Promise<void>).catch === 'function') {
+      (req as Promise<void>).catch(() => { /* user 拒否 or 未対応 */ });
+    }
+  }
+
+  private handleCanvasClick(): void {
+    // FPS モード中で Pointer Lock が外れていたらクリックで再取得
+    if (this.enabled && document.pointerLockElement !== this.canvas) {
+      this.requestPointerLock();
+    }
+  }
+
+  private handleMouseMove(e: MouseEvent): void {
+    if (!this.enabled || document.pointerLockElement !== this.canvas) return;
+    // Pointer Lock では movementX/Y が delta として渡される。
+    // Three.js world (Y up, +Z = game +Y) を上から見下ろすと XZ 平面は CW 回転が正のため、
+    // マウス右移動 → 視点右回転 = world から見て CW 回転 = yaw 増加（ゲーム空間 yaw 規約も同じ符号で動く）
+    this.yaw += e.movementX * FPSConfig.MouseSensitivity;
+    this.pitch -= e.movementY * FPSConfig.MouseSensitivity;
+    if (this.pitch > FPSConfig.PitchLimit) this.pitch = FPSConfig.PitchLimit;
+    if (this.pitch < -FPSConfig.PitchLimit) this.pitch = -FPSConfig.PitchLimit;
+  }
+
+  private handleKeyDown(e: KeyboardEvent): void {
+    switch (e.code) {
+      case 'KeyW': this.keys.w = true; break;
+      case 'KeyA': this.keys.a = true; break;
+      case 'KeyS': this.keys.s = true; break;
+      case 'KeyD': this.keys.d = true; break;
+      case 'Space': this.keys.space = true; e.preventDefault(); break;
+      case 'ControlLeft': case 'ControlRight': this.keys.ctrl = true; break;
+      case 'ShiftLeft': case 'ShiftRight': this.keys.shift = true; break;
+    }
+  }
+
+  private handleKeyUp(e: KeyboardEvent): void {
+    switch (e.code) {
+      case 'KeyW': this.keys.w = false; break;
+      case 'KeyA': this.keys.a = false; break;
+      case 'KeyS': this.keys.s = false; break;
+      case 'KeyD': this.keys.d = false; break;
+      case 'Space': this.keys.space = false; break;
+      case 'ControlLeft': case 'ControlRight': this.keys.ctrl = false; break;
+      case 'ShiftLeft': case 'ShiftRight': this.keys.shift = false; break;
+    }
+  }
+
+  private handlePointerLockChange(): void {
+    // ESC や他要因で Pointer Lock が外れたら FPS モードを終了する
+    if (this.enabled && document.pointerLockElement !== this.canvas) {
+      this.disable();
+    }
+  }
+
+  /** yaw/pitch から forward を計算。
+   *  ゲーム空間: 0° = +X、CCW 正、90° = +Y。
+   *  Three.js world: game(x, y) → world(x, height, y)。よって world XZ 平面で
+   *  forward_world = (cos(yaw), 0, sin(yaw)) と直接対応する（Y 軸は無関係）。
+   */
+  private forwardVector(): THREE.Vector3 {
+    const yawRad = this.yaw * Math.PI / 180;
+    return new THREE.Vector3(Math.cos(yawRad), 0, Math.sin(yawRad));
+  }
+
+  /** カメラ視点での「右」方向（world XZ 平面）。
+   *  Three.js world は Y up、camera.up=(0,1,0)。yaw=0 で forward=(+X) を見ているとき、
+   *  画面右は world +Z（= game +Y）。よって right = (-forward.z, 0, forward.x)。
+   */
+  private rightVector(forward: THREE.Vector3): THREE.Vector3 {
+    return new THREE.Vector3(-forward.z, 0, forward.x);
+  }
+
+  private applyLook(): void {
+    const forward = this.forwardVector();
+    const pitchRad = this.pitch * Math.PI / 180;
+    const cp = Math.cos(pitchRad);
+    const sp = Math.sin(pitchRad);
+    const dir = new THREE.Vector3(cp * forward.x, sp, cp * forward.z);
+    const target = new THREE.Vector3().copy(this.camera.position).add(dir);
+    this.camera.up.set(0, 1, 0);
+    this.camera.lookAt(target);
+  }
+
+  private tick(): void {
+    const now = performance.now();
+    let dt = (now - this.prevTime) / 1000;
+    this.prevTime = now;
+    if (dt > FPSConfig.MaxDeltaSeconds) dt = FPSConfig.MaxDeltaSeconds;
+    if (dt < 0) dt = 0;
+
+    const sprint = this.keys.shift ? FPSConfig.SprintMultiplier : 1;
+    const speed = FPSConfig.MoveSpeed * sprint * dt;
+
+    const forward = this.forwardVector();
+    const right = this.rightVector(forward);
+
+    if (this.keys.w) this.camera.position.addScaledVector(forward, speed);
+    if (this.keys.s) this.camera.position.addScaledVector(forward, -speed);
+    if (this.keys.d) this.camera.position.addScaledVector(right, speed);
+    if (this.keys.a) this.camera.position.addScaledVector(right, -speed);
+    if (this.keys.space) this.camera.position.y += speed;
+    if (this.keys.ctrl)  this.camera.position.y -= speed;
+
+    this.applyLook();
+  }
+}

--- a/src/rendering/MeshUtils.ts
+++ b/src/rendering/MeshUtils.ts
@@ -1,6 +1,15 @@
 import * as THREE from 'three';
 
 /**
+ * Convert game-space (x, y) to Three.js world position.
+ * Game logic uses XY plane; Three.js scene uses XZ plane (Y = up).
+ * Mapping: game(x, y) → three(x, 0, y)
+ */
+export function gameToWorld(gx: number, gy: number, height = 0): THREE.Vector3 {
+  return new THREE.Vector3(gx, height, gy);
+}
+
+/**
  * Creates a placeholder undefined mesh
  */
 export function createUndefinedMesh(): THREE.Mesh {

--- a/src/rendering/NodeWallMeshFactory.ts
+++ b/src/rendering/NodeWallMeshFactory.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { NodeConfig, NodeVisualConfig, WallConfig } from '../config/GameConfig';
+import { NodeConfig, NodeVisualConfig, ShadowConfig, WallConfig } from '../config/GameConfig';
 import { gameToWorld } from './MeshUtils';
 
 /**
@@ -16,9 +16,9 @@ export function createNodeCircle(x: number, y: number, size: number = NodeConfig
     emissiveIntensity: NodeVisualConfig.EmissiveDefaultIntensity,
   });
   const circle = new THREE.Mesh(geometry, material);
-  // Lay the circle flat on the XZ plane
   circle.rotation.x = -Math.PI / 2;
   circle.position.copy(gameToWorld(x, y));
+  circle.receiveShadow = ShadowConfig.Enabled;
   return circle;
 }
 
@@ -44,6 +44,8 @@ export function createWallMesh(x1: number, y1: number, x2: number, y2: number): 
   const mesh = new THREE.Mesh(geo, mat);
   mesh.position.copy(gameToWorld((x1 + x2) / 2, (y1 + y2) / 2, WallConfig.ZOffset));
   mesh.rotation.y = -angle;
+  mesh.castShadow = ShadowConfig.Enabled;
+  mesh.receiveShadow = ShadowConfig.Enabled;
   mesh.userData[WallConfig.UserDataTag] = true;
   return mesh;
 }

--- a/src/rendering/NodeWallMeshFactory.ts
+++ b/src/rendering/NodeWallMeshFactory.ts
@@ -1,8 +1,10 @@
 import * as THREE from 'three';
 import { NodeConfig, NodeVisualConfig, WallConfig } from '../config/GameConfig';
+import { gameToWorld } from './MeshUtils';
 
 /**
- * Creates a node circle mesh
+ * Creates a node circle mesh.
+ * x, y are game-space coordinates; converted to XZ world plane via gameToWorld.
  */
 export function createNodeCircle(x: number, y: number, size: number = NodeConfig.CircleSize): THREE.Mesh {
   const geometry = new THREE.CircleGeometry(size, NodeConfig.CircleSegments).center();
@@ -14,17 +16,21 @@ export function createNodeCircle(x: number, y: number, size: number = NodeConfig
     emissiveIntensity: NodeVisualConfig.EmissiveDefaultIntensity,
   });
   const circle = new THREE.Mesh(geometry, material);
-  circle.position.set(x, y, 0);
+  // Lay the circle flat on the XZ plane
+  circle.rotation.x = -Math.PI / 2;
+  circle.position.copy(gameToWorld(x, y));
   return circle;
 }
 
 /**
- * Creates a 3D wall mesh for obstacle line segments
+ * Creates a 3D wall mesh for obstacle line segments.
+ * x1,y1,x2,y2 are game-space coordinates; placed on the XZ plane via gameToWorld.
  */
 export function createWallMesh(x1: number, y1: number, x2: number, y2: number): THREE.Mesh {
   const dx = x2 - x1;
   const dy = y2 - y1;
   const length = Math.sqrt(dx * dx + dy * dy);
+  // In XZ plane, rotation around Y axis
   const angle = Math.atan2(dy, dx);
 
   const geo = new THREE.BoxGeometry(length, WallConfig.Height, WallConfig.Depth);
@@ -36,8 +42,8 @@ export function createWallMesh(x1: number, y1: number, x2: number, y2: number): 
     emissiveIntensity: WallConfig.EmissiveIntensity,
   });
   const mesh = new THREE.Mesh(geo, mat);
-  mesh.position.set((x1 + x2) / 2, (y1 + y2) / 2, WallConfig.ZOffset);
-  mesh.rotation.z = angle;
+  mesh.position.copy(gameToWorld((x1 + x2) / 2, (y1 + y2) / 2, WallConfig.ZOffset));
+  mesh.rotation.y = -angle;
   mesh.userData[WallConfig.UserDataTag] = true;
   return mesh;
 }

--- a/src/rendering/PlayerLifecycleManager.ts
+++ b/src/rendering/PlayerLifecycleManager.ts
@@ -50,7 +50,7 @@ export class PlayerLifecycleManager {
     const obj = this.playerMeshes.get(playerId);
     if (!obj) return;
 
-    this.setPlayerColor(obj, 0xff0000);
+    this.setPlayerColor(obj, RenderConfig.PlayerHitColor);
 
     gsap.timeline()
       .to(obj.scale, { x: 1.5, y: 1.5, z: 1.5, duration: 0.1, ease: 'power2.out' })

--- a/src/rendering/PlayerLifecycleManager.ts
+++ b/src/rendering/PlayerLifecycleManager.ts
@@ -6,6 +6,7 @@ import { PlayerAnimator } from './PlayerAnimator';
 import { createVariantPlayer } from './PlayerMeshFactory';
 import { AnimationConfig, RenderConfig } from '../config/GameConfig';
 import { PLAYER_CONSTANTS } from '../config/GameConfig';
+import { gameToWorld } from './MeshUtils';
 
 /**
  * Manages the lifecycle of player mesh objects:
@@ -119,23 +120,24 @@ export class PlayerLifecycleManager {
     const obj = this.playerMeshes.get(playerId);
     if (!obj) return false;
 
-    const dx = obj.position.x - targetX;
-    const dy = obj.position.y - targetY;
-    const moving = Math.sqrt(dx * dx + dy * dy) > 0.5;
+    const worldTarget = gameToWorld(targetX, targetY, RenderConfig.PlayerZOffset);
+    const dx = obj.position.x - worldTarget.x;
+    const dz = obj.position.z - worldTarget.z;
+    const moving = Math.sqrt(dx * dx + dz * dz) > 0.5;
 
     if (moving && this.animator.getState(playerId) === 'idle') {
       this.animator.startWalk(playerId);
     }
 
     gsap.to(obj.position, {
-      x: targetX,
-      y: targetY,
+      x: worldTarget.x,
+      y: worldTarget.y,
+      z: worldTarget.z,
       duration: AnimationConfig.MovementDuration,
     });
-    obj.position.z = RenderConfig.PlayerZOffset;
 
-    obj.rotation.x = Math.PI / 2;
-    obj.rotation.y = (angle * Math.PI / 180) + RenderConfig.PlayerFacingOffset;
+    obj.rotation.x = 0;
+    obj.rotation.y = -((angle * Math.PI / 180) + RenderConfig.PlayerFacingOffset);
     obj.rotation.z = 0;
 
     const scale = isActive ? PLAYER_CONSTANTS.ACTIVE_SCALE : PLAYER_CONSTANTS.NORMAL_SCALE;

--- a/src/rendering/PlayerLifecycleManager.ts
+++ b/src/rendering/PlayerLifecycleManager.ts
@@ -109,6 +109,13 @@ export class PlayerLifecycleManager {
   /**
    * Applies position (animated), rotation, and scale to a player mesh.
    * Returns true if the player is moving (so the caller can trigger camera follow).
+   *
+   * Angle convention (game space, atan2(dy, dx) * 180/π):
+   *   0° = +X (right), 90° = +Y, counter-clockwise positive.
+   * Mapping to Three.js rotation.y:
+   *   game(x, y) → world(x, 0, y); model forward is local +Z.
+   *   To face game angle θ, rotation.y = atan2(cosθ, sinθ) = π/2 − θ_rad
+   *   = −θ_rad + PlayerFacingOffset (PlayerFacingOffset = π/2).
    */
   applyTransform(
     playerId: string,
@@ -137,7 +144,7 @@ export class PlayerLifecycleManager {
     });
 
     obj.rotation.x = 0;
-    obj.rotation.y = -((angle * Math.PI / 180) + RenderConfig.PlayerFacingOffset);
+    obj.rotation.y = -(angle * Math.PI / 180) + RenderConfig.PlayerFacingOffset;
     obj.rotation.z = 0;
 
     const scale = isActive ? PLAYER_CONSTANTS.ACTIVE_SCALE : PLAYER_CONSTANTS.NORMAL_SCALE;

--- a/src/rendering/PlayerMeshFactory.ts
+++ b/src/rendering/PlayerMeshFactory.ts
@@ -140,11 +140,11 @@ function buildArmGroup(s: number, HS: number, side: 'left' | 'right', mat: THREE
 }
 
 // ── Gear: handgun (SCOUT) ─────────────────────────────────────────────────────
-// 座標系: PlayerLifecycleManager が rotation.x = π/2 を適用するため
-//   ローカル +Y → 前方（プレイヤーが向く方向）
+// 座標系（rotation.x = 0、ローカル +Z = 前方／+Y = 上）:
+//   ローカル +Z → 前方（プレイヤーが向く方向）
 //   ローカル +X → 右
-//   ローカル +Z → カメラ向き（上から見える面）
-// CylinderGeometry はデフォルトで +Y 向き → 銃身に rotation 不要
+//   ローカル +Y → 上
+// CylinderGeometry はデフォルトで +Y 向き → 銃身に rotation.x = π/2 で +Z へ向ける
 function buildGearGun(s: number, HS: number, rx: number, color: number): THREE.Group {
   const g = new THREE.Group();
   const x = rx + s * 0.06;
@@ -165,14 +165,15 @@ function buildGearGun(s: number, HS: number, rx: number, color: number): THREE.G
   slide.position.set(x, HS * -0.3, 0);
   g.add(slide);
 
-  // 銃身（スライド上端から前方 +Y へ突き出る）
+  // 銃身（スライド前面から前方 +Z へ突き出る）
   const barrel = new THREE.Mesh(
     new THREE.CylinderGeometry(s * 0.03, s * 0.03, HS * 0.7, 6),
     new THREE.MeshStandardMaterial({ color: RenderConfig.PlayerGunBarrelColor, roughness: 0.3, metalness: 0.85 })
   );
   barrel.userData.fixedColor = true;
   barrel.userData.partName = 'barrel';
-  barrel.position.set(x, HS * 0.5, 0);
+  barrel.rotation.x = Math.PI / 2;
+  barrel.position.set(x, HS * -0.3, HS * 0.5);
   g.add(barrel);
 
   return g;
@@ -182,11 +183,10 @@ function buildGearGun(s: number, HS: number, rx: number, color: number): THREE.G
 /**
  * Creates a humanoid Scout player character.
  *
- * Coordinate note: PlayerLifecycleManager applies rotation.x = π/2 to lay the group flat.
- * After that rotation:
- *   local +Y → screen forward (player facing direction)
- *   local ±X → screen left/right
- *   local +Z → toward camera (visible from above)
+ * Coordinate note (rotation.x = 0, model stands upright in world space):
+ *   local +Z → forward (player facing direction)
+ *   local ±X → right/left
+ *   local +Y → up
  */
 export function createVariantPlayer(color: number = RenderConfig.PlayerDefaultColor): THREE.Group {
   const group = new THREE.Group();

--- a/src/rendering/PlayerMeshFactory.ts
+++ b/src/rendering/PlayerMeshFactory.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { RenderConfig } from '../config/GameConfig';
+import { RenderConfig, ShadowConfig } from '../config/GameConfig';
 
 // ── Character part name registry ──────────────────────────────────────────────
 /**
@@ -188,7 +188,7 @@ function buildGearGun(s: number, HS: number, rx: number, color: number): THREE.G
  *   local ±X → screen left/right
  *   local +Z → toward camera (visible from above)
  */
-export function createVariantPlayer(color: number = 0xffff00): THREE.Group {
+export function createVariantPlayer(color: number = RenderConfig.PlayerDefaultColor): THREE.Group {
   const group = new THREE.Group();
   const s = RenderConfig.PlayerMarkerSize;
   const HS = s / 6.4;
@@ -216,6 +216,15 @@ export function createVariantPlayer(color: number = 0xffff00): THREE.Group {
   group.add(new THREE.AxesHelper(s * 1.5));
 
   group.userData.partNames = SCOUT_PART_NAMES;
+
+  if (ShadowConfig.Enabled) {
+    group.traverse((obj) => {
+      if (obj instanceof THREE.Mesh) {
+        obj.castShadow = true;
+        obj.receiveShadow = true;
+      }
+    });
+  }
 
   return group;
 }

--- a/src/rendering/PlayerMeshFactory.ts
+++ b/src/rendering/PlayerMeshFactory.ts
@@ -140,7 +140,7 @@ function buildArmGroup(s: number, HS: number, side: 'left' | 'right', mat: THREE
 }
 
 // ── Gear: handgun (SCOUT) ─────────────────────────────────────────────────────
-// 座標系: VisualizationSync が rotation.x = π/2 を適用するため
+// 座標系: PlayerLifecycleManager が rotation.x = π/2 を適用するため
 //   ローカル +Y → 前方（プレイヤーが向く方向）
 //   ローカル +X → 右
 //   ローカル +Z → カメラ向き（上から見える面）
@@ -182,7 +182,7 @@ function buildGearGun(s: number, HS: number, rx: number, color: number): THREE.G
 /**
  * Creates a humanoid Scout player character.
  *
- * Coordinate note: VisualizationSync applies rotation.x = π/2 to lay the group flat.
+ * Coordinate note: PlayerLifecycleManager applies rotation.x = π/2 to lay the group flat.
  * After that rotation:
  *   local +Y → screen forward (player facing direction)
  *   local ±X → screen left/right
@@ -212,6 +212,8 @@ export function createVariantPlayer(color: number = 0xffff00): THREE.Group {
   group.add(rightArm);
 
   group.add(buildGearGun(s, HS, rx, color));
+
+  group.add(new THREE.AxesHelper(s * 1.5));
 
   group.userData.partNames = SCOUT_PART_NAMES;
 

--- a/src/rendering/SceneManager.ts
+++ b/src/rendering/SceneManager.ts
@@ -15,6 +15,7 @@ export class SceneManager {
   private composer: EffectComposer | null = null;
   private boundHandleResize: () => void;
   private boundHandleWheel: (e: WheelEvent) => void;
+  private tickCallbacks: Set<() => void> = new Set();
 
   constructor(canvas: HTMLCanvasElement) {
     // Setup renderer
@@ -36,9 +37,10 @@ export class SceneManager {
     this.camera.aspect = width / height;
     this.camera.position.set(
       -CameraConfig.BackDistance,
-      0,
       CameraConfig.OffsetZ,
+      0,
     );
+    this.camera.up.set(0, 1, 0);
     this.camera.updateProjectionMatrix();
 
     // Setup controls
@@ -52,6 +54,9 @@ export class SceneManager {
 
     // Add background grid
     this.createBackgroundGrid();
+
+    // Add XYZ axes helper at origin (X=red, Y=green, Z=blue)
+    this.scene.add(new THREE.AxesHelper(MapConfig.NodeSpacing * 3));
 
     // Add lights
     this.addLighting();
@@ -118,15 +123,15 @@ export class SceneManager {
 
     for (let i = 0; i < size; i++) {
       const x = i * spacing;
-      const vPts = [new THREE.Vector3(x, 0, -0.5), new THREE.Vector3(x, total, -0.5)];
+      const vPts = [new THREE.Vector3(x, -0.5, 0), new THREE.Vector3(x, -0.5, total)];
       const vLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(vPts), material);
       vLine.userData['isGrid'] = true;
       this.scene.add(vLine);
     }
 
     for (let i = 0; i < size; i++) {
-      const y = i * spacing;
-      const hPts = [new THREE.Vector3(0, y, -0.5), new THREE.Vector3(total, y, -0.5)];
+      const z = i * spacing;
+      const hPts = [new THREE.Vector3(0, -0.5, z), new THREE.Vector3(total, -0.5, z)];
       const hLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(hPts), material);
       hLine.userData['isGrid'] = true;
       this.scene.add(hLine);
@@ -149,11 +154,11 @@ export class SceneManager {
    */
   panCamera(screenDx: number, screenDy: number, sensitivity: number): void {
     const wx = screenDx * sensitivity;
-    const wy = -screenDy * sensitivity;
+    const wz = screenDy * sensitivity;
     this.camera.position.x += wx;
-    this.camera.position.y += wy;
+    this.camera.position.z += wz;
     this.orbitControls.target.x += wx;
-    this.orbitControls.target.y += wy;
+    this.orbitControls.target.z += wz;
     this.orbitControls.update();
   }
 
@@ -177,10 +182,21 @@ export class SceneManager {
     this.orbitControls.update();
   }
 
+  /** Registers a callback invoked every frame before rendering. */
+  addTickCallback(cb: () => void): void {
+    this.tickCallbacks.add(cb);
+  }
+
+  /** Unregisters a previously added tick callback. */
+  removeTickCallback(cb: () => void): void {
+    this.tickCallbacks.delete(cb);
+  }
+
   /**
    * Renders the scene (via EffectComposer if bloom is enabled)
    */
   render(): void {
+    for (const cb of this.tickCallbacks) cb();
     if (this.composer) {
       this.composer.render();
     } else {

--- a/src/rendering/SceneManager.ts
+++ b/src/rendering/SceneManager.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { EffectComposer, OrbitControls, RenderPass, UnrealBloomPass } from 'three-stdlib';
 import { Vector3 } from 'three';
-import { CameraConfig, LightingConfig, MapConfig, PostProcessConfig, RenderConfig } from '../config/GameConfig';
+import { CameraConfig, FogConfig, LightingConfig, MapConfig, PostProcessConfig, RenderConfig, ShadowConfig } from '../config/GameConfig';
 
 /**
  * Manages Three.js scene, camera, renderer, and controls setup
@@ -28,9 +28,16 @@ export class SceneManager {
     this.renderer.setClearColor(RenderConfig.BackgroundColor);
     this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
     this.renderer.toneMappingExposure = 1.0;
+    if (ShadowConfig.Enabled) {
+      this.renderer.shadowMap.enabled = true;
+      this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    }
 
     // Setup scene
     this.scene = new THREE.Scene();
+    if (FogConfig.Enabled) {
+      this.scene.fog = new THREE.FogExp2(FogConfig.Color, FogConfig.Density);
+    }
 
     // Setup camera
     this.camera = new THREE.PerspectiveCamera(CameraConfig.FOV, 1.0);
@@ -99,12 +106,30 @@ export class SceneManager {
     this.scene.add(hemi);
 
     const dir = new THREE.DirectionalLight(0xffffff, LightingConfig.DirectionalIntensity);
-    dir.position.set(LightingConfig.DirectionalX, LightingConfig.DirectionalY, LightingConfig.DirectionalZ);
+    dir.position.set(LightingConfig.DirectionalOrbitRadius, LightingConfig.DirectionalY, 0);
+    if (ShadowConfig.Enabled) {
+      dir.castShadow = true;
+      dir.shadow.mapSize.set(ShadowConfig.MapSize, ShadowConfig.MapSize);
+      dir.shadow.camera.near = ShadowConfig.CameraNear;
+      dir.shadow.camera.far = ShadowConfig.CameraFar;
+      dir.shadow.camera.left = -ShadowConfig.CameraSize;
+      dir.shadow.camera.right = ShadowConfig.CameraSize;
+      dir.shadow.camera.top = ShadowConfig.CameraSize;
+      dir.shadow.camera.bottom = -ShadowConfig.CameraSize;
+    }
     this.scene.add(dir);
 
-    const rim = new THREE.DirectionalLight(LightingConfig.RimLightColor, LightingConfig.RimLightIntensity);
-    rim.position.set(LightingConfig.RimLightX, LightingConfig.RimLightY, LightingConfig.RimLightZ);
-    this.scene.add(rim);
+    let elapsed = 0;
+    let lastTime = performance.now();
+    this.addTickCallback(() => {
+      const now = performance.now();
+      elapsed += (now - lastTime) * 0.001;
+      lastTime = now;
+      const r = LightingConfig.DirectionalOrbitRadius;
+      const angle = elapsed * LightingConfig.DirectionalOrbitSpeed;
+      dir.position.x = r * Math.cos(angle);
+      dir.position.z = r * Math.sin(angle);
+    });
   }
 
   /**

--- a/src/rendering/TextBurstEffect.ts
+++ b/src/rendering/TextBurstEffect.ts
@@ -7,7 +7,63 @@ const CHARS = ['モ', 'ヒ', 'カ', 'ン'] as const;
 
 
 export class TextBurstEffect {
+  private burstTimers: ReturnType<typeof setInterval>[] = [];
+
   constructor(private sceneManager: SceneManager) {}
+
+  playDanceBurst(worldX: number, worldY: number, worldZ: number): void {
+    const cfg = TextBurstEffectConfig;
+    const camera = this.sceneManager.getCamera();
+
+    let count = 0;
+    const id = setInterval(() => {
+      if (count >= cfg.DanceBurstCount) {
+        clearInterval(id);
+        this.burstTimers = this.burstTimers.filter(t => t !== id);
+        return;
+      }
+
+      const camRight = new THREE.Vector3().setFromMatrixColumn(camera.matrixWorld, 0).normalize();
+      const camUp    = new THREE.Vector3().setFromMatrixColumn(camera.matrixWorld, 1).normalize();
+      const pivot    = new THREE.Vector3(worldX, worldY, worldZ);
+
+      cfg.DanceBurstChars.forEach((char, i) => {
+        // 各文字を均等角度オフセット + ランダムベース角度で飛ばす
+        const baseAngle = Math.random() * Math.PI * 2;
+        const angleRad  = baseAngle + (i / cfg.DanceBurstChars.length) * Math.PI * 2;
+
+        const target = pivot.clone()
+          .addScaledVector(camRight, cfg.DanceBurstFlyRadius * Math.cos(angleRad))
+          .addScaledVector(camUp,    cfg.DanceBurstFlyRadius * Math.sin(angleRad));
+
+        const sprite = this.createSprite(char, cfg.DanceBurstSpriteSize);
+        sprite.position.copy(pivot);
+        this.sceneManager.addToScene(sprite);
+
+        gsap.timeline({
+          onComplete: () => {
+            this.sceneManager.removeFromScene(sprite);
+            (sprite.material as THREE.SpriteMaterial).map?.dispose();
+            (sprite.material as THREE.SpriteMaterial).dispose();
+          },
+        })
+          .to(sprite.position, {
+            x: target.x, y: target.y, z: target.z,
+            duration: cfg.DanceBurstDuration,
+            ease: 'power2.out',
+          }, 0)
+          .to(sprite.material as THREE.SpriteMaterial, {
+            opacity: 0,
+            duration: cfg.DanceBurstDuration,
+            ease: 'power1.in',
+          }, 0);
+      });
+
+      count++;
+    }, cfg.DanceBurstIntervalMs);
+
+    this.burstTimers.push(id);
+  }
 
   play(worldX: number, worldY: number, worldZ: number): void {
     const cfg = TextBurstEffectConfig;
@@ -44,7 +100,6 @@ export class TextBurstEffect {
     const sprites = CHARS.map((char) => {
       const sprite = this.createSprite(char);
       sprite.position.copy(pivot);
-      sprite.scale.setScalar(cfg.SpriteWorldSize);
       this.sceneManager.addToScene(sprite);
       return sprite;
     });
@@ -101,7 +156,7 @@ export class TextBurstEffect {
     });
   }
 
-  private createSprite(char: string): THREE.Sprite {
+  private createSprite(char: string, worldSize?: number): THREE.Sprite {
     const cfg = TextBurstEffectConfig;
     const size = cfg.CanvasSize;
 
@@ -124,6 +179,8 @@ export class TextBurstEffect {
       opacity: 1,
       depthTest: false,
     });
-    return new THREE.Sprite(material);
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.setScalar(worldSize ?? cfg.SpriteWorldSize);
+    return sprite;
   }
 }

--- a/src/rendering/TextBurstEffect.ts
+++ b/src/rendering/TextBurstEffect.ts
@@ -1,0 +1,129 @@
+import * as THREE from 'three';
+import { gsap } from 'gsap';
+import { TextBurstEffectConfig } from '../config/GameConfig';
+import { SceneManager } from './SceneManager';
+
+const CHARS = ['モ', 'ヒ', 'カ', 'ン'] as const;
+
+
+export class TextBurstEffect {
+  constructor(private sceneManager: SceneManager) {}
+
+  play(worldX: number, worldY: number, worldZ: number): void {
+    const cfg = TextBurstEffectConfig;
+    const camera = this.sceneManager.getCamera();
+
+    // カメラの右・上ベクトルを取得（カメラ空間で扇を広げるため）
+    const camRight = new THREE.Vector3();
+    const camUp    = new THREE.Vector3();
+    camera.getWorldDirection(new THREE.Vector3()); // matrixWorld を更新
+    camRight.setFromMatrixColumn(camera.matrixWorld, 0).normalize();
+    camUp.setFromMatrixColumn(camera.matrixWorld, 1).normalize();
+
+    // 支点: プレイヤー位置をカメラ上方向に少し上げた点
+    const pivot = new THREE.Vector3(worldX, worldY, worldZ)
+      .addScaledVector(camUp, cfg.PivotYOffset);
+
+    // 扇形着地座標: 支点を軸に camRight（横）と camUp（縦）で放射状配置
+    const n: number = CHARS.length;
+    const fanHalfAngle = cfg.FanHalfAngleDegPerChar * (n - 1) / 2;
+    const landRadius   = cfg.LandRadiusPerChar * (n - 1) / 2 + cfg.LandRadiusPerChar;
+
+    const fanAngles = CHARS.map((_, i) =>
+      n === 1 ? 0 : -fanHalfAngle + (i / (n - 1)) * fanHalfAngle * 2
+    );
+
+    const landPositions = fanAngles.map(deg => {
+      const rad = (deg * Math.PI) / 180;
+      return pivot.clone()
+        .addScaledVector(camRight, landRadius * Math.sin(rad))
+        .addScaledVector(camUp,    landRadius * Math.cos(rad));
+    });
+
+    // スプライトを生成してシーンに追加し、全文字を支点中心に配置してスタート
+    const sprites = CHARS.map((char) => {
+      const sprite = this.createSprite(char);
+      sprite.position.copy(pivot);
+      sprite.scale.setScalar(cfg.SpriteWorldSize);
+      this.sceneManager.addToScene(sprite);
+      return sprite;
+    });
+
+    // アニメーション timeline
+    const tl = gsap.timeline({
+      onComplete: () => {
+        sprites.forEach(s => {
+          this.sceneManager.removeFromScene(s);
+          (s.material as THREE.SpriteMaterial).map?.dispose();
+          (s.material as THREE.SpriteMaterial).dispose();
+        });
+      },
+    });
+
+    // Phase 1: 全文字が支点中心へ爆速飛び込み
+    sprites.forEach(sprite => {
+      tl.to(sprite.position, {
+        x: pivot.x,
+        y: pivot.y,
+        z: pivot.z,
+        duration: cfg.FlyInDuration,
+        ease: 'power3.out',
+      }, 0);
+    });
+
+    // Phase 2: 扇形に広がる（位置 + 放射方向への回転）
+    sprites.forEach((sprite, i) => {
+      const rotationRad = -(fanAngles[i] * Math.PI) / 180;
+      tl.to(sprite.position, {
+        x: landPositions[i].x,
+        y: landPositions[i].y,
+        z: landPositions[i].z,
+        duration: cfg.FanOpenDuration,
+        ease: 'back.out(1.5)',
+      }, cfg.FlyInDuration);
+      tl.to(sprite.material as THREE.SpriteMaterial, {
+        rotation: rotationRad,
+        duration: cfg.FanOpenDuration,
+        ease: 'back.out(1.5)',
+      }, cfg.FlyInDuration);
+    });
+
+    // Phase 3: 待機
+    tl.to({}, { duration: cfg.HoldDuration }, cfg.FlyInDuration + cfg.FanOpenDuration);
+
+    // Phase 4: フェードアウト
+    sprites.forEach(sprite => {
+      tl.to((sprite.material as THREE.SpriteMaterial), {
+        opacity: 0,
+        duration: cfg.FadeOutDuration,
+        ease: 'power1.in',
+      }, cfg.FlyInDuration + cfg.FanOpenDuration + cfg.HoldDuration);
+    });
+  }
+
+  private createSprite(char: string): THREE.Sprite {
+    const cfg = TextBurstEffectConfig;
+    const size = cfg.CanvasSize;
+
+    const canvas = document.createElement('canvas');
+    canvas.width  = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d')!;
+
+    const fontSize = Math.floor(size * 0.78);
+    ctx.font        = `900 ${fontSize}px sans-serif`;
+    ctx.fillStyle   = cfg.TextColor;
+    ctx.textAlign   = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(char, size / 2, size / 2);
+
+    const texture = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({
+      map: texture,
+      transparent: true,
+      opacity: 1,
+      depthTest: false,
+    });
+    return new THREE.Sprite(material);
+  }
+}

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -23,6 +23,7 @@ export class VisualizationSync {
   private model:         Model;
 
   private activePlayerId: string;
+  private fpsModeActive = false;
 
   constructor(
     sceneManager: SceneManager,
@@ -78,6 +79,16 @@ export class VisualizationSync {
     return this.nodeVis.getMeshToNodeMap();
   }
 
+  /** Returns the camera follow controller (used by FPSCameraController to snap on disable). */
+  getCameraFollow(): CameraFollowController {
+    return this.camera;
+  }
+
+  /** Returns the currently active player ID. */
+  getActivePlayerId(): string {
+    return this.activePlayerId;
+  }
+
   // ── Private helpers ────────────────────────────────────────────────────────
 
   private doUpdateView(): void {
@@ -114,7 +125,7 @@ export class VisualizationSync {
       const moving = this.lifecycle.applyTransform(
         playerId, player.node.x, player.node.y, player.angle, isActive,
       );
-      if (isActive && moving) {
+      if (isActive && moving && !this.fpsModeActive) {
         this.camera.panTo(player.node.x, player.node.y, player.angle, CameraConfig.FollowMoveDuration, CameraConfig.FollowMoveEase);
       }
     }
@@ -126,10 +137,14 @@ export class VisualizationSync {
     eventBus.on(GameEventType.VIS_SET_ACTIVE_PLAYER, (data: { playerId: string }) => {
       this.activePlayerId = data.playerId;
       const player = this.model.getPlayer(data.playerId);
-      if (player) {
+      if (player && !this.fpsModeActive) {
         this.camera.panTo(player.node.x, player.node.y, player.angle, CameraConfig.FollowPanDuration, CameraConfig.FollowPanEase);
       }
       this.doUpdateView();
+    });
+
+    eventBus.on(GameEventType.FPS_MODE_CHANGED, (data: { enabled: boolean }) => {
+      this.fpsModeActive = data.enabled;
     });
 
     eventBus.on(GameEventType.VIS_SET_SELECT_MESH, (data: { nodeId: number }) => {

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -1,23 +1,26 @@
 import * as THREE from 'three';
 import { Model } from '../model/model';
 import { SceneManager } from './SceneManager';
-import { CameraConfig, PlayerConfig } from '../config/GameConfig';
+import { CameraConfig, PlayerConfig, RenderConfig } from '../config/GameConfig';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
 import { PlayerAnimator } from './PlayerAnimator';
 import { PlayerLifecycleManager } from './PlayerLifecycleManager';
 import { CameraFollowController } from './CameraFollowController';
 import { NodeVisualizationManager } from './NodeVisualizationManager';
+import { TextBurstEffect } from './TextBurstEffect';
+import { gameToWorld } from './MeshUtils';
 
 /**
  * Thin orchestrator: constructs the four specialized managers and wires them
  * to GameEventBus. External API is unchanged so threeSetup.ts needs no edits.
  */
 export class VisualizationSync {
-  private nodeVis:   NodeVisualizationManager;
-  private lifecycle: PlayerLifecycleManager;
-  private animator:  PlayerAnimator;
-  private camera:    CameraFollowController;
-  private model:     Model;
+  private nodeVis:       NodeVisualizationManager;
+  private lifecycle:     PlayerLifecycleManager;
+  private animator:      PlayerAnimator;
+  private camera:        CameraFollowController;
+  private mohicanEffect: TextBurstEffect;
+  private model:         Model;
 
   private activePlayerId: string;
 
@@ -32,10 +35,11 @@ export class VisualizationSync {
 
     // Shared map — PlayerAnimator and PlayerLifecycleManager both reference it
     const meshMap = new Map<string, THREE.Object3D>();
-    this.animator  = new PlayerAnimator(meshMap);
-    this.lifecycle = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap);
-    this.nodeVis   = new NodeVisualizationManager(sceneManager, model);
-    this.camera    = new CameraFollowController(sceneManager);
+    this.animator      = new PlayerAnimator(meshMap);
+    this.lifecycle     = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap);
+    this.nodeVis       = new NodeVisualizationManager(sceneManager, model);
+    this.camera        = new CameraFollowController(sceneManager);
+    this.mohicanEffect = new TextBurstEffect(sceneManager);
 
     // Initialize scene objects
     this.nodeVis.initializeNodes();
@@ -165,6 +169,11 @@ export class VisualizationSync {
 
     eventBus.on(GameEventType.VIS_PLAY_DANCE, (data: { playerId: string }) => {
       this.animator.startDance(data.playerId);
+      const player = this.model.getPlayer(data.playerId);
+      if (player) {
+        const w = gameToWorld(player.node.x, player.node.y, RenderConfig.PlayerZOffset);
+        this.mohicanEffect.play(w.x, w.y, w.z);
+      }
     });
   }
 }

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -19,7 +19,7 @@ export class VisualizationSync {
   private lifecycle:     PlayerLifecycleManager;
   private animator:      PlayerAnimator;
   private camera:        CameraFollowController;
-  private mohicanEffect: TextBurstEffect;
+  private textBurstEffect: TextBurstEffect;
   private model:         Model;
 
   private activePlayerId: string;
@@ -39,7 +39,7 @@ export class VisualizationSync {
     this.lifecycle     = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap);
     this.nodeVis       = new NodeVisualizationManager(sceneManager, model);
     this.camera        = new CameraFollowController(sceneManager);
-    this.mohicanEffect = new TextBurstEffect(sceneManager);
+    this.textBurstEffect = new TextBurstEffect(sceneManager);
 
     // Initialize scene objects
     this.nodeVis.initializeNodes();
@@ -172,7 +172,8 @@ export class VisualizationSync {
       const player = this.model.getPlayer(data.playerId);
       if (player) {
         const w = gameToWorld(player.node.x, player.node.y, RenderConfig.PlayerZOffset);
-        this.mohicanEffect.play(w.x, w.y, w.z);
+        this.textBurstEffect.play(w.x, w.y, w.z);
+        this.textBurstEffect.playDanceBurst(w.x, w.y, w.z);
       }
     });
   }

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -1,5 +1,6 @@
 import { SceneManager } from './SceneManager';
 import { VisualizationSync } from './VisualizationSync';
+import { FPSCameraController } from './FPSCameraController';
 import { InputHandler } from '../input/InputHandler';
 import { GameController } from '../logic/GameController';
 import { GameEventBus, GameEventType, gameEventBus } from '../core/GameEventBus';
@@ -19,6 +20,7 @@ export class ThreeSetup {
   private inputHandler: InputHandler;
   private gameController: GameController;
   private eventBus: GameEventBus;
+  private fpsCamera: FPSCameraController;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -70,6 +72,24 @@ export class ThreeSetup {
       adapter.getMyPlayerId(),
       adapter
     );
+
+    // Initialize FPS spectator camera (T キーで通常追従と切替)
+    this.fpsCamera = new FPSCameraController(
+      this.sceneManager.getCamera(),
+      canvas,
+      this.sceneManager,
+      this.visualizationSync.getCameraFollow(),
+      this.eventBus,
+      model,
+      () => this.visualizationSync.getActivePlayerId(),
+    );
+    this.eventBus.on(GameEventType.FPS_MODE_TOGGLE_REQUESTED, () => {
+      if (this.fpsCamera.isEnabled()) {
+        this.fpsCamera.disable();
+      } else {
+        this.fpsCamera.enable();
+      }
+    });
 
     // Re-apply obstacles + redraw if obstacles_ready arrives after initializeModel()
     adapter.onObstaclesReady((obstacles) => {
@@ -136,6 +156,7 @@ export class ThreeSetup {
    * Disposes all resources
    */
   dispose(): void {
+    this.fpsCamera.dispose();
     this.eventBus.removeAllListeners();
     this.sceneManager.dispose();
     this.inputHandler.dispose();

--- a/src/ui/FPSOverlay.tsx
+++ b/src/ui/FPSOverlay.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+/**
+ * FPS 観戦モード中のオーバーレイ UI。
+ * 中央に十字、上端に操作ガイドを表示する。
+ */
+const FPSOverlay: React.FC = () => {
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    pointerEvents: 'none',
+    zIndex: 10,
+  };
+
+  const crosshairBase: React.CSSProperties = {
+    position: 'absolute',
+    left: '50%',
+    top: '50%',
+    background: 'rgba(255, 255, 255, 0.7)',
+    transform: 'translate(-50%, -50%)',
+  };
+
+  const guideStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: 16,
+    left: '50%',
+    transform: 'translateX(-50%)',
+    padding: '6px 14px',
+    background: 'rgba(0, 0, 0, 0.55)',
+    color: '#fff',
+    fontFamily: 'monospace',
+    fontSize: 13,
+    letterSpacing: 0.5,
+    borderRadius: 4,
+  };
+
+  return (
+    <div style={overlayStyle}>
+      {/* horizontal */}
+      <div style={{ ...crosshairBase, width: 14, height: 2 }} />
+      {/* vertical */}
+      <div style={{ ...crosshairBase, width: 2, height: 14 }} />
+      <div style={guideStyle}>
+        観戦モード | WASD: 移動 / Space-Ctrl: 上下 / Shift: 加速 / Mouse: 視点 / F: ダンス / T or ESC: 退出
+      </div>
+    </div>
+  );
+};
+
+export default FPSOverlay;

--- a/src/ui/GRF_main.tsx
+++ b/src/ui/GRF_main.tsx
@@ -4,18 +4,27 @@ import type { ThreeSetup } from '../rendering/threeSetup';
 import GameHUD from './GameHUD';
 import LobbyUI from './LobbyUI';
 import ConsoleLogger from './ConsoleLogger';
+import FPSOverlay from './FPSOverlay';
 import { LocalAdapter } from '../network/LocalAdapter';
 import { ColyseusAdapter } from '../network/ColyseusAdapter';
 import type { INetworkAdapter } from '../network/INetworkAdapter';
+import { gameEventBus, GameEventType } from '../core/GameEventBus';
 
 type AppState = 'lobby' | 'connecting' | 'playing';
 
 const GRF_main = () => {
   const [appState, setAppState] = React.useState<AppState>('lobby');
   const [errorMsg, setErrorMsg] = React.useState('');
+  const [fpsMode, setFpsMode] = React.useState(false);
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const [threeSetup, setThreeSetup] = React.useState<ThreeSetup | null>(null);
   const initialized = React.useRef(false);
+
+  React.useEffect(() => {
+    const onChange = (data: { enabled: boolean }) => setFpsMode(data.enabled);
+    gameEventBus.on(GameEventType.FPS_MODE_CHANGED, onChange);
+    return () => gameEventBus.off(GameEventType.FPS_MODE_CHANGED, onChange);
+  }, []);
 
   React.useEffect(() => {
     return () => {
@@ -68,8 +77,9 @@ const GRF_main = () => {
         ref={canvasRef}
         style={{ display: appState === 'playing' ? 'block' : 'none' }}
       />
-      {appState === 'playing' && <GameHUD threeSetup={threeSetup} />}
-      {appState === 'playing' && <ConsoleLogger />}
+      {appState === 'playing' && !fpsMode && <GameHUD threeSetup={threeSetup} />}
+      {appState === 'playing' && !fpsMode && <ConsoleLogger />}
+      {appState === 'playing' && fpsMode && <FPSOverlay />}
       {appState !== 'playing' && (
         <LobbyUI
           connecting={appState === 'connecting'}

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -10,13 +10,32 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
   const [gridVisible, setGridVisible] = React.useState(true);
   const [playerIds, setPlayerIds] = React.useState<string[]>([]);
   const [activeId, setActiveId] = React.useState<string>('');
+  const [activeAngle, setActiveAngle] = React.useState<number | null>(null);
+
+  const refreshAngle = React.useCallback((id: string) => {
+    if (!threeSetup) return;
+    const player = threeSetup.getModel().players.get(id);
+    setActiveAngle(player ? Math.round(player.angle) : null);
+  }, [threeSetup]);
 
   React.useEffect(() => {
     if (!threeSetup) return;
     const ids = threeSetup.getPlayerIds();
     setPlayerIds(ids);
-    setActiveId(ids[0] ?? '');
-  }, [threeSetup]);
+    const firstId = ids[0] ?? '';
+    setActiveId(firstId);
+    refreshAngle(firstId);
+  }, [threeSetup, refreshAngle]);
+
+  React.useEffect(() => {
+    const onView = () => setActiveAngle(prev => {
+      if (!threeSetup || !activeId) return prev;
+      const player = threeSetup.getModel().players.get(activeId);
+      return player ? Math.round(player.angle) : prev;
+    });
+    gameEventBus.on(GameEventType.VIS_UPDATE_VIEW, onView);
+    return () => gameEventBus.off(GameEventType.VIS_UPDATE_VIEW, onView);
+  }, [threeSetup, activeId]);
 
   const handleToggleGrid = () => {
     if (!threeSetup) return;
@@ -26,6 +45,7 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
 
   const handleSwitchPlayer = (id: string) => {
     setActiveId(id);
+    refreshAngle(id);
     gameEventBus.emit(GameEventType.PLAYER_SWITCHED, {
       previousPlayerId: activeId,
       currentPlayerId: id,
@@ -87,6 +107,18 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
               {id}
             </button>
           ))}
+        </div>
+      )}
+      {activeAngle !== null && (
+        <div style={{
+          color: '#00e5ff',
+          fontSize: '12px',
+          fontFamily: 'monospace',
+          background: 'rgba(0,0,0,0.5)',
+          padding: '3px 8px',
+          borderRadius: '3px',
+        }}>
+          angle: {activeAngle}°
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- ゲーム座標(XY)を Three.js の XZ 平面へ変換し、シック系カラーテーマ／シャドウ／Bloom／Fog／ライト軌道アニメーションを追加
- ダンス時に「ダンス」文字が扇形〜ランダム方向にバーストする `TextBurstEffect` を追加（Fキーで発動）
- WASD + マウスで自由視点になる FPS 観戦モードを追加（Tキーで切替、`FPSCameraController` / `FPSOverlay`）
- プレイヤーモデルの前後逆転を修正

## Test plan
- [ ] `npm run dev` で起動し、Tキーで FPS 観戦モードに切替できることを確認
- [ ] FPS モード中の WASD 移動・マウス視点操作が想定通り動くか
- [ ] Fキーでダンス＆`TextBurstEffect` が再生されるか
- [ ] 通常モードのカメラ追従・選択・射撃フローに回帰がないか
- [ ] `npm run build` / `npm run lint` が通るか

🤖 Generated with [Claude Code](https://claude.com/claude-code)