### PR TITLE
feat: OキーでMAP全体俯瞰のOrthographicカメラを追加

### DIFF
--- a/src/config/camera.ts
+++ b/src/config/camera.ts
@@ -46,6 +46,15 @@ export const CameraConfig = {
 
   /** 移動追従時の ease */
   FollowMoveEase: 'power2.out',
+
+  /** Ortho MAP カメラの初期 halfSize（マップ全体 1470 の半分より少し大きめ） */
+  OrthoViewHalfSize: 800,
+  /** Ortho ズームイン上限 */
+  OrthoViewHalfSizeMin: 200,
+  /** Ortho ズームアウト上限 */
+  OrthoViewHalfSizeMax: 1200,
+  /** Ortho ホイール 1 ステップあたりの halfSize 変化量 */
+  OrthoWheelStep: 40,
 } as const;
 
 /**

--- a/src/config/input.ts
+++ b/src/config/input.ts
@@ -6,4 +6,6 @@ export const KEYBOARD_KEYS = {
   DANCE_UPPER: 'F',
   SPECTATOR_TOGGLE: 't',
   SPECTATOR_TOGGLE_UPPER: 'T',
+  ORTHO_TOGGLE: 'o',
+  ORTHO_TOGGLE_UPPER: 'O',
 } as const;

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -60,6 +60,10 @@ export enum GameEventType {
   FPS_MODE_TOGGLE_REQUESTED = 'fps:toggle_requested',
   FPS_MODE_CHANGED = 'fps:mode_changed',
 
+  // Ortho MAP overview mode events
+  ORTHO_MODE_TOGGLE_REQUESTED = 'ortho:toggle_requested',
+  ORTHO_MODE_CHANGED = 'ortho:mode_changed',
+
   // Network events (Phase 2+: used by ColyseusAdapter)
   NETWORK_CONNECTED = 'network:connected',
   NETWORK_DISCONNECTED = 'network:disconnected',
@@ -179,6 +183,12 @@ export interface GameEventData {
   // Spectator (FPS) mode events
   [GameEventType.FPS_MODE_TOGGLE_REQUESTED]: void;
   [GameEventType.FPS_MODE_CHANGED]: {
+    enabled: boolean;
+  };
+
+  // Ortho MAP overview mode events
+  [GameEventType.ORTHO_MODE_TOGGLE_REQUESTED]: void;
+  [GameEventType.ORTHO_MODE_CHANGED]: {
     enabled: boolean;
   };
 

--- a/src/input/InputHandler.ts
+++ b/src/input/InputHandler.ts
@@ -94,6 +94,14 @@ export class InputHandler {
       return;
     }
 
+    // O キーは Ortho MAP 俯瞰モードのトグル（FPS 中は無効）
+    if (!this.fpsActive &&
+        (event.key === KEYBOARD_KEYS.ORTHO_TOGGLE ||
+         event.key === KEYBOARD_KEYS.ORTHO_TOGGLE_UPPER)) {
+      this.eventBus.emit(GameEventType.ORTHO_MODE_TOGGLE_REQUESTED);
+      return;
+    }
+
     // F キー（ダンス）は観戦モード中も発火させる
     if (event.key === KEYBOARD_KEYS.DANCE ||
         event.key === KEYBOARD_KEYS.DANCE_UPPER) {

--- a/src/rendering/cameras/CameraInputController.ts
+++ b/src/rendering/cameras/CameraInputController.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three-stdlib';
 import { CameraConfig } from '../../config/GameConfig';
+import type { OrthoMapController } from './OrthoMapController';
 
 /**
  * Owns camera input: OrbitControls (rotate / pan), wheel-driven FOV zoom,
@@ -11,6 +12,8 @@ export class CameraInputController {
   private boundHandleWheel: (e: WheelEvent) => void;
   private camera: THREE.PerspectiveCamera;
   private canvas: HTMLCanvasElement;
+  private orthoController: OrthoMapController | null = null;
+  private orthoActive = false;
 
   constructor(camera: THREE.PerspectiveCamera, canvas: HTMLCanvasElement) {
     this.camera = camera;
@@ -28,15 +31,28 @@ export class CameraInputController {
     canvas.addEventListener('wheel', this.boundHandleWheel, { passive: false });
   }
 
-  /** Wheel-driven FOV adjustment (clamped). */
+  setOrthoController(ctrl: OrthoMapController): void {
+    this.orthoController = ctrl;
+  }
+
+  setOrthoActive(active: boolean): void {
+    this.orthoActive = active;
+  }
+
+  /** Wheel-driven zoom: Ortho モード時は halfSize 調整、Perspective 時は FOV 調整。 */
   private handleWheel(e: WheelEvent): void {
     e.preventDefault();
-    const delta = e.deltaY > 0 ? CameraConfig.FOVWheelStep : -CameraConfig.FOVWheelStep;
-    this.camera.fov = Math.max(
-      CameraConfig.FOVMin,
-      Math.min(CameraConfig.FOVMax, this.camera.fov + delta),
-    );
-    this.camera.updateProjectionMatrix();
+    if (this.orthoActive && this.orthoController) {
+      const delta = e.deltaY > 0 ? CameraConfig.OrthoWheelStep : -CameraConfig.OrthoWheelStep;
+      this.orthoController.zoom(delta);
+    } else {
+      const delta = e.deltaY > 0 ? CameraConfig.FOVWheelStep : -CameraConfig.FOVWheelStep;
+      this.camera.fov = Math.max(
+        CameraConfig.FOVMin,
+        Math.min(CameraConfig.FOVMax, this.camera.fov + delta),
+      );
+      this.camera.updateProjectionMatrix();
+    }
   }
 
   /**

--- a/src/rendering/cameras/OrthoMapController.ts
+++ b/src/rendering/cameras/OrthoMapController.ts
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+import { CameraConfig, CalculatedConfig } from '../../config/GameConfig';
+
+/**
+ * MAP全体を固定俯瞰表示する OrthographicCamera コントローラー。
+ * O キーで通常の PerspectiveCamera と切り替える。
+ * ホイールで halfSize を変更してズームイン/アウトできる。
+ */
+export class OrthoMapController {
+  private camera: THREE.OrthographicCamera;
+  private enabled = false;
+
+  constructor() {
+    const mapSize = CalculatedConfig.MapSize;
+    const cx = mapSize / 2;
+    const aspect = window.innerWidth / window.innerHeight;
+    const h = CameraConfig.OrthoViewHalfSize;
+    this.camera = new THREE.OrthographicCamera(
+      -h * aspect, h * aspect,
+       h, -h,
+      CameraConfig.MinDistance,
+      CameraConfig.MaxDistance,
+    );
+    this.camera.position.set(cx, CameraConfig.OffsetZ, cx);
+    // Three.js XZ平面を真上から見るとき、up=(0,1,0) + lookAt(真下) はジンバルロックする
+    // → up を -Z にして回避
+    this.camera.up.set(0, 0, -1);
+    this.camera.lookAt(cx, 0, cx);
+    this.camera.updateProjectionMatrix();
+  }
+
+  getCamera(): THREE.OrthographicCamera {
+    return this.camera;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  enable(): void {
+    this.enabled = true;
+  }
+
+  disable(): void {
+    this.enabled = false;
+  }
+
+  handleResize(): void {
+    const aspect = window.innerWidth / window.innerHeight;
+    const h = this.camera.top;
+    this.camera.left  = -h * aspect;
+    this.camera.right =  h * aspect;
+    this.camera.updateProjectionMatrix();
+  }
+
+  zoom(delta: number): void {
+    const newH = Math.max(
+      CameraConfig.OrthoViewHalfSizeMin,
+      Math.min(CameraConfig.OrthoViewHalfSizeMax, this.camera.top + delta),
+    );
+    const aspect = this.camera.right / this.camera.top;
+    this.camera.left   = -newH * aspect;
+    this.camera.right  =  newH * aspect;
+    this.camera.top    =  newH;
+    this.camera.bottom = -newH;
+    this.camera.updateProjectionMatrix();
+  }
+}

--- a/src/rendering/core/PostProcessing.ts
+++ b/src/rendering/core/PostProcessing.ts
@@ -28,7 +28,7 @@ export function applyFogToScene(scene: THREE.Scene): void {
 export function setupPostProcessing(
   renderer: THREE.WebGLRenderer,
   scene: THREE.Scene,
-  camera: THREE.PerspectiveCamera,
+  camera: THREE.Camera,
   width: number,
   height: number,
 ): EffectComposer | null {

--- a/src/rendering/core/SceneManager.ts
+++ b/src/rendering/core/SceneManager.ts
@@ -15,6 +15,7 @@ export class SceneManager {
   private renderer: THREE.WebGLRenderer;
   private scene: THREE.Scene;
   private camera: THREE.PerspectiveCamera;
+  private activeCamera: THREE.Camera;
   private composer: EffectComposer | null;
   private backgroundGrid: BackgroundGrid;
   private boundHandleResize: () => void;
@@ -54,6 +55,8 @@ export class SceneManager {
 
     this.composer = setupPostProcessing(this.renderer, this.scene, this.camera, width, height);
 
+    this.activeCamera = this.camera;
+
     this.boundHandleResize = this.handleResize.bind(this);
     window.addEventListener('resize', this.boundHandleResize);
   }
@@ -73,7 +76,7 @@ export class SceneManager {
     if (this.composer) {
       this.composer.render();
     } else {
-      this.renderer.render(this.scene, this.camera);
+      this.renderer.render(this.scene, this.activeCamera);
     }
   }
 
@@ -103,6 +106,18 @@ export class SceneManager {
 
   getCamera(): THREE.PerspectiveCamera {
     return this.camera;
+  }
+
+  setActiveCamera(cam: THREE.Camera): void {
+    this.activeCamera = cam;
+    if (this.composer) {
+      // EffectComposer の passes[0] は RenderPass — カメラを差し替える
+      (this.composer.passes[0] as unknown as { camera: THREE.Camera }).camera = cam;
+    }
+  }
+
+  getActiveCamera(): THREE.Camera {
+    return this.activeCamera;
   }
 
   getRenderer(): THREE.WebGLRenderer {

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -2,6 +2,7 @@ import { SceneManager } from './core/SceneManager';
 import { VisualizationSync } from './VisualizationSync';
 import { CameraInputController } from './cameras/CameraInputController';
 import { FPSCameraController } from './cameras/FPSCameraController';
+import { OrthoMapController } from './cameras/OrthoMapController';
 import { InputHandler } from '../input/InputHandler';
 import { GameController } from '../logic/GameController';
 import { GameEventBus, GameEventType, gameEventBus } from '../core/GameEventBus';
@@ -23,6 +24,7 @@ export class ThreeSetup {
   private gameController: GameController;
   private eventBus: GameEventBus;
   private fpsCamera: FPSCameraController;
+  private orthoController: OrthoMapController;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -94,6 +96,23 @@ export class ThreeSetup {
         this.fpsCamera.disable();
       } else {
         this.fpsCamera.enable();
+      }
+    });
+
+    // Ortho MAP 俯瞰モード（O キー）
+    this.orthoController = new OrthoMapController();
+    this.cameraInput.setOrthoController(this.orthoController);
+    this.eventBus.on(GameEventType.ORTHO_MODE_TOGGLE_REQUESTED, () => {
+      if (this.orthoController.isEnabled()) {
+        this.orthoController.disable();
+        this.cameraInput.setOrthoActive(false);
+        this.sceneManager.setActiveCamera(this.sceneManager.getCamera());
+        this.eventBus.emit(GameEventType.ORTHO_MODE_CHANGED, { enabled: false });
+      } else {
+        this.orthoController.enable();
+        this.cameraInput.setOrthoActive(true);
+        this.sceneManager.setActiveCamera(this.orthoController.getCamera());
+        this.eventBus.emit(GameEventType.ORTHO_MODE_CHANGED, { enabled: true });
       }
     });
 


### PR DESCRIPTION
## Summary

- **O キー**で通常の PerspectiveCamera（プレイヤー追従）と OrthographicCamera（MAP全体固定俯瞰）を切り替え可能にした
- Ortho モード時のホイールは halfSize 調整によるズームイン/アウト（Perspective 時は従来の FOV 調整を維持）
- FPS モード（T キー）との干渉なし。FPS 中は O キーを無効化

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/rendering/cameras/OrthoMapController.ts` | 新規作成。MAP中央真上に固定した OrthographicCamera とホイールズーム |
| `src/rendering/core/SceneManager.ts` | `activeCamera` 追加、`setActiveCamera()` でランタイム切り替え |
| `src/rendering/cameras/CameraInputController.ts` | Ortho/Perspective でホイール処理を分岐 |
| `src/core/GameEventBus.ts` | `ORTHO_MODE_TOGGLE_REQUESTED` / `ORTHO_MODE_CHANGED` イベント追加 |
| `src/rendering/threeSetup.ts` | OrthoMapController の配線・O キーのトグルリスナ登録 |
| `src/input/InputHandler.ts` | O キーで `ORTHO_MODE_TOGGLE_REQUESTED` 発火 |
| `src/config/camera.ts` | `OrthoViewHalfSize` 等の定数追加 |
| `src/config/input.ts` | `ORTHO_TOGGLE: 'o'` キー定数追加 |

## Test plan

- [ ] O キー押下でマップ全体が俯瞰表示になる
- [ ] Ortho モード中のホイールでズームイン/アウトが機能する
- [ ] O キー再押下で通常のプレイヤー追従 Perspective カメラに戻る
- [ ] T キー（FPS モード）と O キーが互いに干渉しない
- [ ] `npm run build` でビルドエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)