### PR TITLE
feat: 3チームNPC観戦モード + ThreatMap AI意思決定システム

### DIFF
--- a/document/npc-ai.md
+++ b/document/npc-ai.md
@@ -4,20 +4,49 @@
 
 NPC の行動は毎ターン `TurnManager.collectNPCActions()` によって収集され、人間プレイヤーの行動と同時に解決される。各 NPC は **目的地ノード** に向かいながら、視野内の敵を射撃する。
 
+NPC の判断は「全知」ではなく、**チームが観測した情報のみ**を使う。視界外の敵の正確な位置は参照しない（ThreatMap ベースの推定情報を使用）。
+
 ---
 
 ## ターンごとの処理フロー
 
 ```
 TurnManager.collectNPCActions()
+  ├─ _updateThreatMaps()   ─ チームごとに ThreatMap を更新（1ターン1回）
   └─ 各生存NPC に対して:
       ├─ updateGoal()      ─ 目的地の再評価判定と更新
       └─ decideTurn()      ─ TurnAction を生成
-            ├─ getPathToNode()       ─ 目的地までの経路を取得
+            ├─ getPathToNode()        ─ 目的地までの経路を取得
             ├─ 経路の1ステップ先へ移動
-            ├─ getAngleBetweenNodes() ─ 最近敵へ向く
-            └─ selectShotTarget()   ─ 視野内の敵を射撃
+            ├─ getAngleBetweenNodes() ─ 最近敵または高脅威方向へ向く
+            └─ selectShotTarget()    ─ 視野内の敵を射撃
 ```
+
+---
+
+## ThreatMap（脅威マップ）
+
+### 概要
+
+チームごとに保持する**ノードごとの敵存在確率（0.0〜1.0）**。毎ターン `observeAndRescore()` で更新される。
+
+| 値 | 意味 |
+|----|------|
+| `1.0` | 今ターン敵を直接確認 |
+| `0.5〜0.9` | 数ターン前に確認、まだ居る可能性が高い |
+| `0.1〜0.4` | 観測から時間が経ち確率が薄れた |
+| `0.0` | 確認されていない（または確実にクリア） |
+
+### 更新メカニズム
+
+1. **観測**: チーム全員のFOV合算（`getTeamVisibleNodes()`）で見えたノードを記録
+2. **減衰**: 前ターンのスコアに `ThreatAccumulationDecay (0.85)` を乗算
+3. **上書き**: 今ターン見えたノードは `1.0`（敵あり）または `0.0`（クリア）で確定
+4. **BFS拡散**: スコアが隣接ノードへ広がる（`ThreatSpreadFactor × exp(-dist/ThreatSigma)`）
+
+### 適用チーム
+
+`AIConfig.ThreatMapTeams` = `[0, 1, 2, 3, 4, 5]`（全チーム）
 
 ---
 
@@ -35,7 +64,7 @@ TurnManager.collectNPCActions()
 
 ### 目的地の再評価条件
 
-以下のいずれかを満たすと目的地を再評価する（優先度順）。
+以下のいずれかを満たすと目的地を再評価する。
 
 | 条件 | 説明 |
 |------|------|
@@ -46,9 +75,9 @@ TurnManager.collectNPCActions()
 ### 目的地の選定ロジック (`selectGoalNode`)
 
 1. `getReachableNodes(現在地, GoalSearchRadius=8)` で BFS 半径 8 以内の全到達ノードを取得
-2. 各ノードに `scoreNode()` を適用（下記「移動ノードスコアリング」参照）
-3. スコア最大・かつ未占有のノードを目的地に設定
-4. 到達可能ノードがない場合は現在地を維持
+2. `getTeamVisibleNodes(npc.id)` でチーム視野を取得（scoreNode に渡す）
+3. 各ノードに `scoreNode()` + `threatMap.getScore() × ThreatMapGoalBonus (50)` を適用
+4. スコア最大・かつ未占有のノードを目的地に設定
 
 ### 経路追従 (`decideTurn`)
 
@@ -63,67 +92,93 @@ getPathToNode(現在地, goalNodeId, Infinity)
 
 ## 移動ノードスコアリング (`scoreNode`)
 
-目的地選定・毎ターンの移動先評価の両方で使われる共通スコア関数。
+目的地選定で使われる共通スコア関数。**ThreatMap とチーム視野のみを参照**し、視界外の敵の正確な位置は使わない。
+
+### 関数シグネチャ
+
+```typescript
+scoreNode(
+  model: Model,
+  npc: Player,
+  candidateNodeId: number,
+  enemies: Player[],              // チーム視認中の敵のみ内部で使用
+  threatMap: ThreatMap | null,
+  teamVisibleNodeIds: Set<number>,
+): number
+```
 
 ### スコア計算式
 
 ```
-score = カバースコア + LOS評価 + アンブッシュボーナス + 距離スコア
+score = カバースコア + 露出ペナルティ + アンブッシュボーナス + 距離スコア
 ```
 
 ### 1. カバースコア
 
-壁に接しているほど高評価。グラフのエッジ数（4方向の通路数）が少ないほど壁が多い。
+壁に接しているほど高評価。グラフのエッジ数（通路数）が少ないほど壁が多い。
 
 ```
 coverScore = 4 - エッジ数          (0〜4)
 coverWeight = CoverWeight (30)
-            ※ HP < RetreatHPThreshold (40) のとき × RetreatCoverMultiplier (2)
+            ※ HP < RetreatHPThreshold (40) のとき × RetreatCoverMultiplier (2) = 60
 
-score += coverScore × coverWeight
+score += coverScore × coverWeight   // 最大 +240
 ```
 
-### 2. 敵 LOS 評価
+### 2. 敵LOS露出ペナルティ
 
-敵から視線が通るノードはペナルティ。
+視界外の未観測ノードは ThreatMap の確率で重み付けしたペナルティ。チーム視認中の敵は確定ペナルティ。
 
 ```
-敵ごとに:
-  敵がこのノードを見える → score += EnemyLOSPenalty (-20)
+// 2a: 未観測ノードからの確率的ペナルティ
+全ノード走査:
+  threat = threatMap.getScore(nid)
+  if threat ≤ ScorerThreatExposureMin (0.1): スキップ
+  if チーム視認中ノード:                      スキップ（2bで処理）
+  if nid → 候補ノードへ LOS あり:
+    score += EnemyLOSPenalty (-20) × threat  ← 確率で減衰
+
+// 2b: チームが直接見ている敵からのフルペナルティ
+視認中の敵ごとに:
+  if 敵 → 候補ノードへ LOS あり:
+    score += EnemyLOSPenalty (-20)
 ```
 
 ### 3. アンブッシュボーナス
 
-NPC からは敵が見えるが、敵からは NPC が見えない場合にボーナス。
+チームが視認中の敵に射線が通る位置に加点。旧版（LOS対称のため常に0だった）を修正済み。
 
 ```
-敵ごとに:
-  NPC → 敵: LOS あり  かつ  敵 → NPC: LOS なし
-    → score += AmbushBonus (15)
+視認中の敵ごとに:
+  if 候補ノード → 敵へ LOS あり:
+    score += AmbushBonus (+15)
 ```
 
-### 4. 距離スコア（マンハッタン距離）
+### 4. 距離スコア
+
+チーム視認中の敵を優先し、いなければ脅威加重重心を使う。
 
 ```
-minDistance = 最近敵までのマンハッタン距離（グリッド単位）
+// 優先1: 視認敵がいる場合
+targetDist = 最も近い視認敵へのマンハッタン距離
 
-HP >= RetreatHPThreshold (40)  ─ 通常モード（敵に近づく）
-  score += minDistance × DistanceWeight (-2)
-  ※ 距離が大きいほど減点 → 敵に近づくほど高スコア
+// 優先2: 視認敵がいない場合 → 脅威加重重心
+重心(cx, cy) = Σ(threat × position) / Σthreat  (threat > 0.1 のノードのみ)
+targetDist = 候補ノードと重心のマンハッタン距離
 
-HP < RetreatHPThreshold (40)   ─ 撤退モード（敵から遠ざかる）
-  score += minDistance × |DistanceWeight| (+2)
-  ※ 距離が大きいほど加点 → 敵から遠ざかるほど高スコア
+HP >= RetreatHPThreshold (40): score += targetDist × DistanceWeight (-2)   ← 近づく
+HP <  RetreatHPThreshold (40): score += targetDist × |DistanceWeight| (+2)  ← 撤退
 ```
+
+敵・脅威情報が一切なければ距離スコアはスキップ（カバースコアのみで評価）。
 
 ---
 
 ## 向き（照準角度）の決定
 
-移動先ノードから **最近の敵** に向く角度を `atan2(dy, dx)` で計算する。
-
-- 敵が複数いる場合はユークリッド距離が最小の敵を優先
-- 敵が0体の場合は前ターンの角度を維持
+1. 視野内に敵がいれば最近の敵に向く（`atan2(dy, dx)`）
+2. 敵がいない場合かつ `ThreatMapAngleEnabled = true` なら、ThreatMap の高脅威ノード方向に向く（`getHighestThreatNodeFrom()`）
+3. 上記いずれもなければ前ターンの角度を維持
 
 ---
 
@@ -131,7 +186,7 @@ HP < RetreatHPThreshold (40)   ─ 撤退モード（敵から遠ざかる）
 
 ### 射撃可能条件
 
-移動先ノードから以下の両方を満たす敵ノードのみが対象。
+移動先ノードから以下の全てを満たす敵のみが対象。
 
 | 条件 | 設定値 |
 |------|--------|
@@ -148,14 +203,13 @@ dist    = 移動先ノード〜敵ノードのマンハッタン距離
 score = hpBonus - dist
 ```
 
-- **低 HP の敵を優先**（hpBonus が大きい）
-- 距離が大きいと減点（同 HP なら近い敵を優先）
+低 HP の敵を優先、同 HP なら近い敵を優先。
 
 ---
 
 ## 占有ノード判定
 
-同一ノードへの複数 NPC の移動を防ぐため、候補ノードに生存プレイヤーが既にいる場合はスキップする。
+同一ノードへの複数 NPC の移動を防ぐため、候補ノードに生存プレイヤーが既にいる場合はスキップ。
 
 - `isNodeOccupied(model, nodeId, excludeId)` で判定
 - 目的地選定時・移動ステップ取得時の両方で適用
@@ -167,7 +221,7 @@ score = hpBonus - dist
 | 定数 | 値 | 説明 |
 |------|----|------|
 | `CoverWeight` | 30 | カバースコアの基本重み |
-| `EnemyLOSPenalty` | -20 | 敵 LOS ペナルティ（敵1体あたり） |
+| `EnemyLOSPenalty` | -20 | 敵 LOS ペナルティ（1件あたり） |
 | `DistanceWeight` | -2 | 距離スコアの重み（負値 = 近づく） |
 | `AmbushBonus` | 15 | アンブッシュボーナス |
 | `RetreatHPThreshold` | 40 | 撤退モードに切り替わる HP 閾値 |
@@ -177,6 +231,15 @@ score = hpBonus - dist
 | `GoalTimeoutTurns` | 10 | 強制再評価までのターン数 |
 | `GoalHPChangeThreshold` | 30 | 再評価をトリガーする HP 低下量 |
 | `RoundAnimationDelayMs` | 1500 | ラウンドアニメーション待機時間（ms） |
+| `ThreatMapTeams` | `[0..5]` | ThreatMap を使うチーム（全チーム） |
+| `ThreatMapGoalBonus` | 50 | 目的地選定時の ThreatMap 加算重み |
+| `ThreatAccumulationDecay` | 0.85 | 毎ターンの脅威スコア減衰率 |
+| `ThreatSpreadFactor` | 1.2 | BFS 拡散係数 |
+| `ThreatSigma` | 4 | BFS 拡散の距離スケール |
+| `ThreatMaxDiffusionSteps` | 1 | BFS 最大拡散ステップ数 |
+| `ThreatMapMaxLookDistance` | 8 | 向き決定の脅威探索 BFS 半径 |
+| `ThreatMapAngleEnabled` | true | 脅威マップ方向への照準を有効化 |
+| `ScorerThreatExposureMin` | 0.1 | scoreNode が無視する脅威スコア下限 |
 
 ---
 
@@ -184,11 +247,12 @@ score = hpBonus - dist
 
 | ファイル | 役割 |
 |---------|------|
-| `src/logic/TurnManager.ts` | NPC 行動収集・目的地 Map 管理 |
+| `src/logic/TurnManager.ts` | NPC 行動収集・ThreatMap 更新・目的地 Map 管理 |
 | `src/logic/ai/NPCBrain.ts` | 行動決定エントリポイント・経路追従 |
 | `src/logic/ai/NPCGoalState.ts` | 目的地状態の型定義 |
 | `src/logic/ai/NPCGoalManager.ts` | 目的地選定・再評価ロジック |
-| `src/logic/ai/NodeScorer.ts` | ノードスコアリング |
+| `src/logic/ai/NodeScorer.ts` | ノードスコアリング（ThreatMap ベース） |
+| `src/logic/ai/ThreatMap.ts` | チームごとの脅威マップ（観測・減衰・BFS拡散） |
 | `src/logic/ai/ShotSelector.ts` | 射撃対象選択 |
 | `src/config/ai.ts` | AI 定数一元管理 |
-| `src/model/model.ts` | `getReachableNodes` / `getPathToNode` / `hasLineOfSight` / `getVisibleNodesAtAngle` |
+| `src/model/model.ts` | `getReachableNodes` / `getPathToNode` / `hasLineOfSight` / `getTeamVisibleNodes` |

--- a/document/npc-ai.md
+++ b/document/npc-ai.md
@@ -1,0 +1,194 @@
+# NPC AI 仕様書
+
+## 概要
+
+NPC の行動は毎ターン `TurnManager.collectNPCActions()` によって収集され、人間プレイヤーの行動と同時に解決される。各 NPC は **目的地ノード** に向かいながら、視野内の敵を射撃する。
+
+---
+
+## ターンごとの処理フロー
+
+```
+TurnManager.collectNPCActions()
+  └─ 各生存NPC に対して:
+      ├─ updateGoal()      ─ 目的地の再評価判定と更新
+      └─ decideTurn()      ─ TurnAction を生成
+            ├─ getPathToNode()       ─ 目的地までの経路を取得
+            ├─ 経路の1ステップ先へ移動
+            ├─ getAngleBetweenNodes() ─ 最近敵へ向く
+            └─ selectShotTarget()   ─ 視野内の敵を射撃
+```
+
+---
+
+## 目的地システム
+
+### 目的地状態 (`NPCGoalState`)
+
+各 NPC ごとに `TurnManager` が `Map<playerId, NPCGoalState>` で保持する。
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| `goalNodeId` | `number` | 目的地ノード ID |
+| `goalSetAtHP` | `number` | 目的地設定時の HP |
+| `turnsElapsed` | `number` | 目的地設定からの経過ターン数 |
+
+### 目的地の再評価条件
+
+以下のいずれかを満たすと目的地を再評価する（優先度順）。
+
+| 条件 | 説明 |
+|------|------|
+| 目的地に到達 | `npc.node.id === goal.goalNodeId` |
+| 大きなダメージを受けた | `npc.health < goal.goalSetAtHP - GoalHPChangeThreshold (30)` |
+| タイムアウト | `goal.turnsElapsed >= GoalTimeoutTurns (10)` |
+
+### 目的地の選定ロジック (`selectGoalNode`)
+
+1. `getReachableNodes(現在地, GoalSearchRadius=8)` で BFS 半径 8 以内の全到達ノードを取得
+2. 各ノードに `scoreNode()` を適用（下記「移動ノードスコアリング」参照）
+3. スコア最大・かつ未占有のノードを目的地に設定
+4. 到達可能ノードがない場合は現在地を維持
+
+### 経路追従 (`decideTurn`)
+
+```
+getPathToNode(現在地, goalNodeId, Infinity)
+  → path[1] が未占有 → そこへ移動 (MoveRange = 1 ステップ)
+  → path[1] が占有済み → 現在地に留まる
+  → 経路が取得できない → 現在地に留まる
+```
+
+---
+
+## 移動ノードスコアリング (`scoreNode`)
+
+目的地選定・毎ターンの移動先評価の両方で使われる共通スコア関数。
+
+### スコア計算式
+
+```
+score = カバースコア + LOS評価 + アンブッシュボーナス + 距離スコア
+```
+
+### 1. カバースコア
+
+壁に接しているほど高評価。グラフのエッジ数（4方向の通路数）が少ないほど壁が多い。
+
+```
+coverScore = 4 - エッジ数          (0〜4)
+coverWeight = CoverWeight (30)
+            ※ HP < RetreatHPThreshold (40) のとき × RetreatCoverMultiplier (2)
+
+score += coverScore × coverWeight
+```
+
+### 2. 敵 LOS 評価
+
+敵から視線が通るノードはペナルティ。
+
+```
+敵ごとに:
+  敵がこのノードを見える → score += EnemyLOSPenalty (-20)
+```
+
+### 3. アンブッシュボーナス
+
+NPC からは敵が見えるが、敵からは NPC が見えない場合にボーナス。
+
+```
+敵ごとに:
+  NPC → 敵: LOS あり  かつ  敵 → NPC: LOS なし
+    → score += AmbushBonus (15)
+```
+
+### 4. 距離スコア（マンハッタン距離）
+
+```
+minDistance = 最近敵までのマンハッタン距離（グリッド単位）
+
+HP >= RetreatHPThreshold (40)  ─ 通常モード（敵に近づく）
+  score += minDistance × DistanceWeight (-2)
+  ※ 距離が大きいほど減点 → 敵に近づくほど高スコア
+
+HP < RetreatHPThreshold (40)   ─ 撤退モード（敵から遠ざかる）
+  score += minDistance × |DistanceWeight| (+2)
+  ※ 距離が大きいほど加点 → 敵から遠ざかるほど高スコア
+```
+
+---
+
+## 向き（照準角度）の決定
+
+移動先ノードから **最近の敵** に向く角度を `atan2(dy, dx)` で計算する。
+
+- 敵が複数いる場合はユークリッド距離が最小の敵を優先
+- 敵が0体の場合は前ターンの角度を維持
+
+---
+
+## 射撃対象の選択 (`selectShotTarget`)
+
+### 射撃可能条件
+
+移動先ノードから以下の両方を満たす敵ノードのみが対象。
+
+| 条件 | 設定値 |
+|------|--------|
+| 視野角（FOV）以内 | `ViewAngle = 60°`（片側 30°） |
+| 視認距離以内 | `MaxViewDistance = 1000 px` |
+| LOS（障害物なし） | `hasLineOfSight()` が true |
+
+### ターゲット優先度スコア
+
+```
+hpBonus = (enemy.maxHealth - enemy.health) / enemy.maxHealth × ShotLowHPPriority (10)
+dist    = 移動先ノード〜敵ノードのマンハッタン距離
+
+score = hpBonus - dist
+```
+
+- **低 HP の敵を優先**（hpBonus が大きい）
+- 距離が大きいと減点（同 HP なら近い敵を優先）
+
+---
+
+## 占有ノード判定
+
+同一ノードへの複数 NPC の移動を防ぐため、候補ノードに生存プレイヤーが既にいる場合はスキップする。
+
+- `isNodeOccupied(model, nodeId, excludeId)` で判定
+- 目的地選定時・移動ステップ取得時の両方で適用
+
+---
+
+## AIConfig パラメータ一覧
+
+| 定数 | 値 | 説明 |
+|------|----|------|
+| `CoverWeight` | 30 | カバースコアの基本重み |
+| `EnemyLOSPenalty` | -20 | 敵 LOS ペナルティ（敵1体あたり） |
+| `DistanceWeight` | -2 | 距離スコアの重み（負値 = 近づく） |
+| `AmbushBonus` | 15 | アンブッシュボーナス |
+| `RetreatHPThreshold` | 40 | 撤退モードに切り替わる HP 閾値 |
+| `RetreatCoverMultiplier` | 2 | 撤退時のカバー重み乗数 |
+| `ShotLowHPPriority` | 10 | 低 HP 敵への射撃優先ボーナス係数 |
+| `GoalSearchRadius` | 8 | 目的地探索の BFS 半径（ステップ数） |
+| `GoalTimeoutTurns` | 10 | 強制再評価までのターン数 |
+| `GoalHPChangeThreshold` | 30 | 再評価をトリガーする HP 低下量 |
+| `RoundAnimationDelayMs` | 1500 | ラウンドアニメーション待機時間（ms） |
+
+---
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `src/logic/TurnManager.ts` | NPC 行動収集・目的地 Map 管理 |
+| `src/logic/ai/NPCBrain.ts` | 行動決定エントリポイント・経路追従 |
+| `src/logic/ai/NPCGoalState.ts` | 目的地状態の型定義 |
+| `src/logic/ai/NPCGoalManager.ts` | 目的地選定・再評価ロジック |
+| `src/logic/ai/NodeScorer.ts` | ノードスコアリング |
+| `src/logic/ai/ShotSelector.ts` | 射撃対象選択 |
+| `src/config/ai.ts` | AI 定数一元管理 |
+| `src/model/model.ts` | `getReachableNodes` / `getPathToNode` / `hasLineOfSight` / `getVisibleNodesAtAngle` |

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -20,7 +20,7 @@ export { AIConfig } from './ai';
 export { CameraConfig, FPSConfig } from './camera';
 export { KEYBOARD_KEYS } from './input';
 export { AnimationConfig, TextBurstEffectConfig } from './animation';
-export { RenderConfig, NodeConfig, NodeVisualConfig, WallConfig, HPBarConfig } from './rendering';
+export { RenderConfig, NodeConfig, NodeVisualConfig, WallConfig, HPBarConfig, ScoreLabelConfig } from './rendering';
 export { LightingConfig, FogConfig, ShadowConfig, PostProcessConfig } from './scene';
 export { applyServerConfig } from './server-sync';
 export type { TeamId } from './team';

--- a/src/config/GameConfig.ts
+++ b/src/config/GameConfig.ts
@@ -12,6 +12,8 @@ export {
   HUMAN_PLAYER_IDS,
   LOCAL_PLAYER_COUNT,
   LOCAL_NPC_COUNT,
+  LOCAL_TEAM_COUNT,
+  LOCAL_NPC_PER_TEAM,
   createPlayerId,
 } from './player';
 export { AIConfig } from './ai';
@@ -22,4 +24,4 @@ export { RenderConfig, NodeConfig, NodeVisualConfig, WallConfig, HPBarConfig } f
 export { LightingConfig, FogConfig, ShadowConfig, PostProcessConfig } from './scene';
 export { applyServerConfig } from './server-sync';
 export type { TeamId } from './team';
-export { TeamConfig } from './team';
+export { TeamConfig, TEAM_COLORS } from './team';

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -38,17 +38,20 @@ export const AIConfig = {
   /** Enable ThreatMap-based facing angle when no visible enemies */
   ThreatMapAngleEnabled: true,
 
-  /** Time constant for threat score decay (rounds) */
-  ThreatTau: 8,
+  /** Per-round multiplier applied to accumulated threat scores before diffusion. Controls fade speed. */
+  ThreatAccumulationDecay: 0.85,
+
+  /** Fraction of a node's score that spreads outward during BFS diffusion. */
+  ThreatSpreadFactor: 1.2,
 
   /** BFS diffusion distance scale */
-  ThreatSigma: 2,
+  ThreatSigma: 4,
 
   /** Maximum BFS steps for threat diffusion */
-  ThreatMaxDiffusionSteps: 6,
+  ThreatMaxDiffusionSteps: 1,
 
   /** Upper bound for ambient threat score on long-unobserved nodes */
-  ThreatAmbientCap: 0.3,
+  ThreatAmbientCap: 0,
 
   /** BFS range when searching for highest-threat node to face */
   ThreatMapMaxLookDistance: 8,

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -55,4 +55,10 @@ export const AIConfig = {
 
   /** BFS range when searching for highest-threat node to face */
   ThreatMapMaxLookDistance: 8,
+
+  /** Teams that use ThreatMap for goal selection, facing, and heatmap visualization. */
+  ThreatMapTeams: [2, 5] as number[],
+
+  /** Weight for ThreatMap score bonus when selecting a patrol goal node */
+  ThreatMapGoalBonus: 50,
 } as const;

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -34,4 +34,22 @@ export const AIConfig = {
 
   /** Re-evaluate goal if HP drops by this amount since goal was set */
   GoalHPChangeThreshold: 30,
+
+  /** Enable ThreatMap-based facing angle when no visible enemies */
+  ThreatMapAngleEnabled: true,
+
+  /** Time constant for threat score decay (rounds) */
+  ThreatTau: 8,
+
+  /** BFS diffusion distance scale */
+  ThreatSigma: 2,
+
+  /** Maximum BFS steps for threat diffusion */
+  ThreatMaxDiffusionSteps: 6,
+
+  /** Upper bound for ambient threat score on long-unobserved nodes */
+  ThreatAmbientCap: 0.3,
+
+  /** BFS range when searching for highest-threat node to face */
+  ThreatMapMaxLookDistance: 8,
 } as const;

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -25,4 +25,13 @@ export const AIConfig = {
 
   /** Waiting time after a simultaneous round resolves before re-enabling input (ms) */
   RoundAnimationDelayMs: 1500,
+
+  /** BFS radius used when searching for a goal node */
+  GoalSearchRadius: 8,
+
+  /** Force goal re-evaluation after this many turns without reaching the goal */
+  GoalTimeoutTurns: 10,
+
+  /** Re-evaluate goal if HP drops by this amount since goal was set */
+  GoalHPChangeThreshold: 30,
 } as const;

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -57,8 +57,11 @@ export const AIConfig = {
   ThreatMapMaxLookDistance: 8,
 
   /** Teams that use ThreatMap for goal selection, facing, and heatmap visualization. */
-  ThreatMapTeams: [2, 5] as number[],
+  ThreatMapTeams: [0, 1, 2, 3, 4, 5] as number[],
 
   /** Weight for ThreatMap score bonus when selecting a patrol goal node */
   ThreatMapGoalBonus: 50,
+
+  /** Threshold below which NodeScorer ignores a node's threat score for exposure/distance calc */
+  ScorerThreatExposureMin: 0.1,
 } as const;

--- a/src/config/input.ts
+++ b/src/config/input.ts
@@ -8,4 +8,6 @@ export const KEYBOARD_KEYS = {
   SPECTATOR_TOGGLE_UPPER: 'T',
   ORTHO_TOGGLE: 'o',
   ORTHO_TOGGLE_UPPER: 'O',
+  NEXT_ROUND: 'r',
+  NEXT_ROUND_UPPER: 'R',
 } as const;

--- a/src/config/map.ts
+++ b/src/config/map.ts
@@ -7,7 +7,7 @@ export const MapConfig: {
   ObstacleMargin: number;
 } = {
   /** Number of nodes in grid (map will be NodesInGridSize x NodesInGridSize) */
-  NodesInGridSize: 20,
+  NodesInGridSize: 30,
 
   /** Spacing between nodes in pixels */
   NodeSpacing: 30,
@@ -21,10 +21,10 @@ export const MapConfig: {
  */
 export const BSPMapConfig = {
   /** Maximum BSP recursion depth */
-  MaxDepth: 1,
+  MaxDepth: 3,
 
   /** Minimum cell size (px) before stopping subdivision */
-  MinCellSize: 200,
+  MinCellSize: 300,
 
   /** Split ratio range minimum (prevents extreme thin cells) */
   SplitMinRatio: 0.35,

--- a/src/config/player.ts
+++ b/src/config/player.ts
@@ -47,10 +47,10 @@ export const PlayerConfig: {
 export const LOCAL_PLAYER_COUNT = 0;
 
 /** チーム数 */
-export const LOCAL_TEAM_COUNT = 3;
+export const LOCAL_TEAM_COUNT = 6;
 
 /** チームごとのNPC数 */
-export const LOCAL_NPC_PER_TEAM = 5;
+export const LOCAL_NPC_PER_TEAM = 10;
 
 /**
  * Number of NPC opponents in local-play mode.

--- a/src/config/player.ts
+++ b/src/config/player.ts
@@ -42,14 +42,20 @@ export const PlayerConfig: {
 
 /**
  * Number of human players in local-play mode.
- * Online mode uses the room's participant count instead.
+ * 0 = 観戦モード（全員NPC）
  */
-export const LOCAL_PLAYER_COUNT = 5;
+export const LOCAL_PLAYER_COUNT = 0;
+
+/** チーム数 */
+export const LOCAL_TEAM_COUNT = 3;
+
+/** チームごとのNPC数 */
+export const LOCAL_NPC_PER_TEAM = 5;
 
 /**
  * Number of NPC opponents in local-play mode.
  */
-export const LOCAL_NPC_COUNT = 5;
+export const LOCAL_NPC_COUNT = LOCAL_TEAM_COUNT * LOCAL_NPC_PER_TEAM;
 
 /**
  * Generate a player ID from an index

--- a/src/config/rendering.ts
+++ b/src/config/rendering.ts
@@ -136,6 +136,18 @@ export const WallConfig = {
  * All sizes are in Three.js world units (PlayerMarkerSize = 20 scale).
  * Head top Y ≈ 13.26 (HS*1.3 + headR*s = 4.06 + 9.2), bar at YOffset=16 gives 2.74 units clearance.
  */
+export const ScoreLabelConfig = {
+  Height: 3.0,
+  SpriteWorldSize: 7,
+  CanvasSize: 128,
+  FontSizeRatio: 0.55,
+  ColorHigh: '#44ff88',
+  ColorLow:  '#ff4444',
+  ColorMid:  '#ffcc00',
+  BgColor: 'rgba(0, 0, 0, 0.6)',
+  BgPaddingRatio: 0.08,
+} as const;
+
 export const HPBarConfig = {
   Width:        14,
   Height:       1.5,

--- a/src/config/rendering.ts
+++ b/src/config/rendering.ts
@@ -11,6 +11,12 @@ export const RenderConfig = {
   /** Grid line opacity */
   GridLineOpacity: 0.6,
 
+  /** LOS (line-of-sight) ray color */
+  LOSLineColor: 0x334455,
+
+  /** LOS ray opacity */
+  LOSLineOpacity: 0.35,
+
   /** Player diamond marker size */
   PlayerMarkerSize: 20,
 

--- a/src/config/scene.ts
+++ b/src/config/scene.ts
@@ -37,7 +37,7 @@ export const FogConfig = {
  */
 export const ShadowConfig = {
   /** Enable shadow maps */
-  Enabled: true,
+  Enabled: false,
   /** Shadow map size (higher = sharper, more expensive) */
   MapSize: 2048,
   /** Shadow camera near clip */
@@ -53,7 +53,7 @@ export const ShadowConfig = {
  */
 export const PostProcessConfig = {
   /** Enable bloom post-processing */
-  EnableBloom: true,
+  EnableBloom: false,
   /** Bloom effect strength */
   BloomStrength: 0.8,
   /** Bloom effect radius */

--- a/src/config/team.ts
+++ b/src/config/team.ts
@@ -1,6 +1,13 @@
-export type TeamId = 0 | 1;
+export type TeamId = 0 | 1 | 2;
 
 export const TeamConfig = {
   Team0Color: 0xff3333,
   Team1Color: 0x3399ff,
+  Team2Color: 0x33ff66,
 } as const;
+
+export const TEAM_COLORS: Record<TeamId, number> = {
+  0: TeamConfig.Team0Color,
+  1: TeamConfig.Team1Color,
+  2: TeamConfig.Team2Color,
+};

--- a/src/config/team.ts
+++ b/src/config/team.ts
@@ -1,13 +1,19 @@
-export type TeamId = 0 | 1 | 2;
+export type TeamId = 0 | 1 | 2 | 3 | 4 | 5;
 
 export const TeamConfig = {
   Team0Color: 0xff3333,
   Team1Color: 0x3399ff,
   Team2Color: 0x33ff66,
+  Team3Color: 0xff9900,
+  Team4Color: 0xcc33ff,
+  Team5Color: 0xffff00,
 } as const;
 
 export const TEAM_COLORS: Record<TeamId, number> = {
   0: TeamConfig.Team0Color,
   1: TeamConfig.Team1Color,
   2: TeamConfig.Team2Color,
+  3: TeamConfig.Team3Color,
+  4: TeamConfig.Team4Color,
+  5: TeamConfig.Team5Color,
 };

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -84,6 +84,9 @@ export enum GameEventType {
   // ThreatMap heatmap visualization
   VIS_THREAT_MAP_UPDATED = 'vis:threat_map_updated',
 
+  // ScoreNode label visualization
+  VIS_SCORENODE_LABELS = 'vis:scorenode_labels',
+
   // Network events (Phase 2+: used by ColyseusAdapter)
   NETWORK_CONNECTED = 'network:connected',
   NETWORK_DISCONNECTED = 'network:disconnected',
@@ -239,6 +242,11 @@ export interface GameEventData {
   [GameEventType.VIS_THREAT_MAP_UPDATED]: {
     scores: Float32Array;
     teamColor: number;
+  };
+
+  // ScoreNode label visualization
+  [GameEventType.VIS_SCORENODE_LABELS]: {
+    scores: Map<number, number> | null;
   };
 
   // Network events

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -74,6 +74,9 @@ export enum GameEventType {
   SPECTATOR_SET_AUTO_LOOP = 'spectator:set_auto_loop',
   SPECTATOR_AUTO_LOOP_CHANGED = 'spectator:auto_loop_changed',
 
+  // Spectator player selection
+  SPECTATOR_SELECT_PLAYER = 'spectator:select_player',
+
   // Ortho MAP overview mode events
   ORTHO_MODE_TOGGLE_REQUESTED = 'ortho:toggle_requested',
   ORTHO_MODE_CHANGED = 'ortho:mode_changed',
@@ -219,6 +222,9 @@ export interface GameEventData {
   // Spectator auto-loop control
   [GameEventType.SPECTATOR_SET_AUTO_LOOP]: { enabled: boolean };
   [GameEventType.SPECTATOR_AUTO_LOOP_CHANGED]: { enabled: boolean };
+
+  // Spectator player selection
+  [GameEventType.SPECTATOR_SELECT_PLAYER]: { playerId: string };
 
   // Ortho MAP overview mode events
   [GameEventType.ORTHO_MODE_TOGGLE_REQUESTED]: void;

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -70,6 +70,10 @@ export enum GameEventType {
   FPS_MODE_TOGGLE_REQUESTED = 'fps:toggle_requested',
   FPS_MODE_CHANGED = 'fps:mode_changed',
 
+  // Spectator auto-loop control
+  SPECTATOR_SET_AUTO_LOOP = 'spectator:set_auto_loop',
+  SPECTATOR_AUTO_LOOP_CHANGED = 'spectator:auto_loop_changed',
+
   // Ortho MAP overview mode events
   ORTHO_MODE_TOGGLE_REQUESTED = 'ortho:toggle_requested',
   ORTHO_MODE_CHANGED = 'ortho:mode_changed',
@@ -211,6 +215,10 @@ export interface GameEventData {
   [GameEventType.FPS_MODE_CHANGED]: {
     enabled: boolean;
   };
+
+  // Spectator auto-loop control
+  [GameEventType.SPECTATOR_SET_AUTO_LOOP]: { enabled: boolean };
+  [GameEventType.SPECTATOR_AUTO_LOOP_CHANGED]: { enabled: boolean };
 
   // Ortho MAP overview mode events
   [GameEventType.ORTHO_MODE_TOGGLE_REQUESTED]: void;

--- a/src/core/GameEventBus.ts
+++ b/src/core/GameEventBus.ts
@@ -81,6 +81,9 @@ export enum GameEventType {
   ORTHO_MODE_TOGGLE_REQUESTED = 'ortho:toggle_requested',
   ORTHO_MODE_CHANGED = 'ortho:mode_changed',
 
+  // ThreatMap heatmap visualization
+  VIS_THREAT_MAP_UPDATED = 'vis:threat_map_updated',
+
   // Network events (Phase 2+: used by ColyseusAdapter)
   NETWORK_CONNECTED = 'network:connected',
   NETWORK_DISCONNECTED = 'network:disconnected',
@@ -230,6 +233,12 @@ export interface GameEventData {
   [GameEventType.ORTHO_MODE_TOGGLE_REQUESTED]: void;
   [GameEventType.ORTHO_MODE_CHANGED]: {
     enabled: boolean;
+  };
+
+  // ThreatMap heatmap visualization
+  [GameEventType.VIS_THREAT_MAP_UPDATED]: {
+    scores: Float32Array;
+    teamColor: number;
   };
 
   // Network events

--- a/src/input/InputHandler.ts
+++ b/src/input/InputHandler.ts
@@ -109,6 +109,13 @@ export class InputHandler {
       return;
     }
 
+    // R キー（手動ラウンド実行）は FPS モード中も受け付ける
+    if (event.key === KEYBOARD_KEYS.NEXT_ROUND ||
+        event.key === KEYBOARD_KEYS.NEXT_ROUND_UPPER) {
+      this.eventBus.emit(GameEventType.NPC_ONLY_TURN);
+      return;
+    }
+
     if (this.fpsActive) return;
 
     this.eventBus.emit(GameEventType.KEY_PRESSED, { key: event.key });

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -17,6 +17,7 @@ export class GameController {
   private stateMachines: Map<string, StateMachine> = new Map();
   private turnManager: TurnManager;
   private inputLocked: boolean = false;
+  private autoLoop: boolean = true;
 
   private allHumanPlayerIds: string[] = [];
   private pendingNextNodeId: Map<string, number | undefined> = new Map();
@@ -83,6 +84,11 @@ export class GameController {
     this.eventBus.on(GameEventType.HIT_DETECTED, this.handleHitDetected.bind(this));
     this.eventBus.on(GameEventType.INPUT_LOCKED, (data: { locked: boolean }) => {
       this.inputLocked = data.locked;
+    });
+    this.eventBus.on(GameEventType.SPECTATOR_SET_AUTO_LOOP, ({ enabled }) => {
+      this.autoLoop = enabled;
+      this.eventBus.emit(GameEventType.SPECTATOR_AUTO_LOOP_CHANGED, { enabled });
+      if (enabled) this.startAutoLoop();
     });
     this.eventBus.on(GameEventType.NPC_ONLY_TURN, () => {
       if (this.inputLocked) return;
@@ -275,8 +281,8 @@ export class GameController {
   }
 
   private startAutoLoop(): void {
-    if (this.allHumanPlayerIds.length === 0) {
-      this.eventBus.emit(GameEventType.NPC_ONLY_TURN);
+    if (this.allHumanPlayerIds.length === 0 && this.autoLoop) {
+      setTimeout(() => this.eventBus.emit(GameEventType.NPC_ONLY_TURN), 0);
     }
   }
 

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -90,6 +90,13 @@ export class GameController {
       this.eventBus.emit(GameEventType.SPECTATOR_AUTO_LOOP_CHANGED, { enabled });
       if (enabled) this.startAutoLoop();
     });
+    this.eventBus.on(GameEventType.SPECTATOR_SELECT_PLAYER, ({ playerId }) => {
+      if (this.inputLocked) return;
+      const player = this.model.getPlayer(playerId);
+      if (!player || !player.isAlive) return;
+      this.activePlayerId = playerId;
+      this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId });
+    });
     this.eventBus.on(GameEventType.NPC_ONLY_TURN, () => {
       if (this.inputLocked) return;
       this.executeNPCOnlyTurn();

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -95,7 +95,11 @@ export class GameController {
         this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId: this.activePlayerId });
         this.eventBus.emit(GameEventType.INPUT_LOCKED, { locked: false });
         this.resetAllStateMachines();
-        this.enterSelectMode(this.allHumanPlayerIds[0] ?? this.activePlayerId);
+        if (this.allHumanPlayerIds.length > 0) {
+          this.enterSelectMode(this.allHumanPlayerIds[0]);
+        } else {
+          this.startAutoLoop();
+        }
       }
     });
   }
@@ -217,7 +221,11 @@ export class GameController {
       this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId: this.activePlayerId });
       this.eventBus.emit(GameEventType.INPUT_LOCKED, { locked: false });
       this.resetAllStateMachines();
-      this.enterSelectMode(this.allHumanPlayerIds[0] ?? this.activePlayerId);
+      if (this.allHumanPlayerIds.length > 0) {
+        this.enterSelectMode(this.allHumanPlayerIds[0]);
+      } else {
+        this.startAutoLoop();
+      }
     }
   }
 
@@ -235,14 +243,12 @@ export class GameController {
     if (!this.networkAdapter.supportsNPC()) return;
 
     const activePlayer = this.model.getPlayer(this.activePlayerId);
-    if (!activePlayer) return;
-
-    const stayAction: TurnAction = {
+    const stayActions: TurnAction[] = activePlayer ? [{
       playerId: this.activePlayerId,
       moveToNodeId: activePlayer.node.id,
       shotAtNodeId: undefined,
-    };
-    const allActions: TurnAction[] = [stayAction, ...this.turnManager.collectNPCActions()];
+    }] : [];
+    const allActions: TurnAction[] = [...stayActions, ...this.turnManager.collectNPCActions()];
 
     const resolved = resolveRoundPaths(allActions, this.model, PlayerConfig.MoveRange);
     this.pendingPaths = new Map(resolved.map(r => [r.playerId, r.path]));
@@ -264,13 +270,24 @@ export class GameController {
     if (this.pendingAnimCount === 0) {
       this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId: this.activePlayerId });
       this.eventBus.emit(GameEventType.INPUT_LOCKED, { locked: false });
+      this.startAutoLoop();
+    }
+  }
+
+  private startAutoLoop(): void {
+    if (this.allHumanPlayerIds.length === 0) {
+      this.eventBus.emit(GameEventType.NPC_ONLY_TURN);
     }
   }
 
   private handleGameStarted(): void {
     console.log(`▶ Game started! (${this.networkAdapter.getMyPlayerId()})`);
     this.eventBus.emit(GameEventType.VIS_UPDATE_VIEW);
-    this.enterSelectMode(this.allHumanPlayerIds[0] ?? this.activePlayerId);
+    if (this.allHumanPlayerIds.length > 0) {
+      this.enterSelectMode(this.allHumanPlayerIds[0]);
+    } else {
+      this.startAutoLoop();
+    }
   }
 
   /**

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -223,7 +223,8 @@ export class GameController {
     const allActions: TurnAction[] = Array.from(this.confirmedActions.values());
 
     if (this.networkAdapter.supportsNPC()) {
-      allActions.push(...this.turnManager.collectNPCActions());
+      const activeTeam = this.model.getPlayer(this.activePlayerId)?.team ?? null;
+      allActions.push(...this.turnManager.collectNPCActions(activeTeam));
     }
 
     const resolved = resolveRoundPaths(allActions, this.model, PlayerConfig.MoveRange);
@@ -275,7 +276,8 @@ export class GameController {
       moveToNodeId: activePlayer.node.id,
       shotAtNodeId: undefined,
     }] : [];
-    const allActions: TurnAction[] = [...stayActions, ...this.turnManager.collectNPCActions()];
+    const activeTeam = this.model.getPlayer(this.activePlayerId)?.team ?? null;
+    const allActions: TurnAction[] = [...stayActions, ...this.turnManager.collectNPCActions(activeTeam)];
 
     const resolved = resolveRoundPaths(allActions, this.model, PlayerConfig.MoveRange);
     this.pendingPaths = new Map(resolved.map(r => [r.playerId, r.path]));

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -386,9 +386,11 @@ export class GameController {
   private computeScoreNodeLabels(npc: Player): Map<number, number> {
     const enemies = this.model.getEnemyPlayers(npc.id);
     const reachable = this.model.getReachableNodes(npc.node.id, AIConfig.GoalSearchRadius);
+    const teamVisibleNodeIds = this.model.getTeamVisibleNodes(npc.id);
+    const threatMap = this.turnManager.getThreatMapForTeam(npc.team);
     const result = new Map<number, number>();
     for (const nodeId of reachable) {
-      result.set(nodeId, scoreNode(this.model, npc, nodeId, enemies));
+      result.set(nodeId, scoreNode(this.model, npc, nodeId, enemies, threatMap, teamVisibleNodeIds));
     }
     return result;
   }

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -59,7 +59,7 @@ export class GameController {
       this.reachableNodesPerPlayer.set(id, new Set());
     }
 
-    this.turnManager = new TurnManager(model, () => this.roundNumber);
+    this.turnManager = new TurnManager(model, () => this.roundNumber, eventBus);
 
     this.networkAdapter.onTurnResult(this.applyTurnResult.bind(this));
     this.networkAdapter.onGameStarted(this.handleGameStarted.bind(this));

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -31,6 +31,9 @@ export class GameController {
   /** Number of path animations still in progress; input unlocks when this reaches 0 */
   private pendingAnimCount = 0;
 
+  /** Monotonically increasing round counter, injected into TurnManager for ThreatMap. */
+  private roundNumber: number = 0;
+
   private inputCommandHandler: InputCommandHandler;
   private pendingPaths: Map<string, number[]> = new Map();
 
@@ -56,7 +59,7 @@ export class GameController {
       this.reachableNodesPerPlayer.set(id, new Set());
     }
 
-    this.turnManager = new TurnManager(model);
+    this.turnManager = new TurnManager(model, () => this.roundNumber);
 
     this.networkAdapter.onTurnResult(this.applyTurnResult.bind(this));
     this.networkAdapter.onGameStarted(this.handleGameStarted.bind(this));
@@ -207,6 +210,7 @@ export class GameController {
    * Executes all confirmed actions simultaneously once every human player has confirmed.
    */
   private executeRound(): void {
+    ++this.roundNumber;
     const allActions: TurnAction[] = Array.from(this.confirmedActions.values());
 
     if (this.networkAdapter.supportsNPC()) {
@@ -254,6 +258,7 @@ export class GameController {
 
   private executeNPCOnlyTurn(): void {
     if (!this.networkAdapter.supportsNPC()) return;
+    ++this.roundNumber;
 
     const activePlayer = this.model.getPlayer(this.activePlayerId);
     const stayActions: TurnAction[] = activePlayer ? [{

--- a/src/logic/GameController.ts
+++ b/src/logic/GameController.ts
@@ -1,8 +1,10 @@
 import { Model } from '../model/model';
+import { Player } from '../model/Player';
 import type { ObstacleData } from '../model/MapGenerator';
 import { GameEvent, StateMachine } from './StateMachine';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
-import { PlayerConfig, HUMAN_PLAYER_IDS } from '../config/GameConfig';
+import { PlayerConfig, HUMAN_PLAYER_IDS, AIConfig } from '../config/GameConfig';
+import { scoreNode } from './ai/NodeScorer';
 import { INetworkAdapter } from '../network/INetworkAdapter';
 import type { TurnAction, TurnResult } from '../schema/types';
 import { TurnManager } from './TurnManager';
@@ -99,6 +101,13 @@ export class GameController {
       if (!player || !player.isAlive) return;
       this.activePlayerId = playerId;
       this.eventBus.emit(GameEventType.VIS_SET_ACTIVE_PLAYER, { playerId });
+
+      if (player.isNPC) {
+        const scores = this.computeScoreNodeLabels(player);
+        this.eventBus.emit(GameEventType.VIS_SCORENODE_LABELS, { scores });
+      } else {
+        this.eventBus.emit(GameEventType.VIS_SCORENODE_LABELS, { scores: null });
+      }
     });
     this.eventBus.on(GameEventType.NPC_ONLY_TURN, () => {
       if (this.inputLocked) return;
@@ -372,6 +381,16 @@ export class GameController {
 
   getModel(): Model {
     return this.model;
+  }
+
+  private computeScoreNodeLabels(npc: Player): Map<number, number> {
+    const enemies = this.model.getEnemyPlayers(npc.id);
+    const reachable = this.model.getReachableNodes(npc.node.id, AIConfig.GoalSearchRadius);
+    const result = new Map<number, number>();
+    for (const nodeId of reachable) {
+      result.set(nodeId, scoreNode(this.model, npc, nodeId, enemies));
+    }
+    return result;
   }
 
   importObstacles(obstaclesData: ObstacleData[]): void {

--- a/src/logic/InputCommandHandler.ts
+++ b/src/logic/InputCommandHandler.ts
@@ -48,7 +48,7 @@ export class InputCommandHandler {
 
     const activePlayerId = this.ctx.getActivePlayerId();
     const activePlayer = this.ctx.model.getPlayer(activePlayerId);
-    if (!activePlayer) return;
+    if (!activePlayer || activePlayer.isNPC) return;
 
     const sm = this.ctx.getStateMachine(activePlayerId);
     const clickedNode = this.ctx.model.nodeList[data.nodeId];
@@ -136,6 +136,9 @@ export class InputCommandHandler {
     if (this.ctx.isInputLocked()) return;
 
     const activePlayerId = this.ctx.getActivePlayerId();
+    const activePlayer = this.ctx.model.getPlayer(activePlayerId);
+    if (!activePlayer || activePlayer.isNPC) return;
+
     const sm = this.ctx.getStateMachine(activePlayerId);
     sm.transition(GameEvent.Cancel);
     this.ctx.setPendingShotNodeIdForPlayer(activePlayerId, undefined);
@@ -144,7 +147,6 @@ export class InputCommandHandler {
     this.ctx.eventBus.emit(GameEventType.VIS_CLEAR_NEXT_MESH);
     this.ctx.eventBus.emit(GameEventType.VIS_CLEAR_MOVE_PATH);
 
-    const activePlayer = this.ctx.model.getPlayer(activePlayerId);
     if (activePlayer) {
       const reachableNodes = this.ctx.model.getReachableNodes(activePlayer.node.id, PlayerConfig.MoveRange);
       this.ctx.setReachableNodesForPlayer(activePlayerId, reachableNodes);

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -1,6 +1,9 @@
 import { Model } from '../model/model';
+import { Player } from '../model/Player';
 import { TurnAction } from '../schema/types';
 import { decideTurn } from './ai/NPCBrain';
+import { NPCGoalState } from './ai/NPCGoalState';
+import { selectGoalNode, updateGoal } from './ai/NPCGoalManager';
 
 /**
  * Collects NPC turn decisions for simultaneous round execution.
@@ -8,6 +11,7 @@ import { decideTurn } from './ai/NPCBrain';
  */
 export class TurnManager {
   private model: Model;
+  private npcGoals: Map<string, NPCGoalState> = new Map();
 
   constructor(model: Model) {
     this.model = model;
@@ -18,10 +22,35 @@ export class TurnManager {
    * Does NOT execute or apply any actions — the caller submits them as a round.
    */
   collectNPCActions(): TurnAction[] {
-    return this.getAliveNPCs().map(npc => decideTurn(this.model, npc));
+    const aliveNPCs = this.getAliveNPCs();
+
+    // Remove goals for NPCs that are no longer alive
+    for (const id of this.npcGoals.keys()) {
+      if (!aliveNPCs.some(n => n.id === id)) {
+        this.npcGoals.delete(id);
+      }
+    }
+
+    return aliveNPCs.map(npc => {
+      const goal = this.getOrInitGoal(npc);
+      const updated = updateGoal(this.model, npc, goal);
+      this.npcGoals.set(npc.id, updated);
+      return decideTurn(this.model, npc, updated);
+    });
   }
 
-  private getAliveNPCs() {
+  private getOrInitGoal(npc: Player): NPCGoalState {
+    if (!this.npcGoals.has(npc.id)) {
+      return {
+        goalNodeId: selectGoalNode(this.model, npc),
+        goalSetAtHP: npc.health,
+        turnsElapsed: 0,
+      };
+    }
+    return this.npcGoals.get(npc.id)!;
+  }
+
+  private getAliveNPCs(): Player[] {
     return Array.from(this.model.players.values())
       .filter(p => p.isNPC && p.isAlive);
   }

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -6,7 +6,7 @@ import { NPCGoalState } from './ai/NPCGoalState';
 import { selectGoalNode, updateGoal } from './ai/NPCGoalManager';
 import { ThreatMap } from './ai/ThreatMap';
 import type { TeamId } from '../config/GameConfig';
-import { TEAM_COLORS } from '../config/GameConfig';
+import { TEAM_COLORS, AIConfig } from '../config/GameConfig';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
 
 /**
@@ -47,21 +47,24 @@ export class TurnManager {
 
     const actions = aliveNPCs.map(npc => {
       const goal = this.getOrInitGoal(npc);
-      const updated = updateGoal(this.model, npc, goal);
+      const threatMap = (AIConfig.ThreatMapTeams as number[]).includes(npc.team)
+        ? this._getThreatMap(npc.team as TeamId) : null;
+      const updated = updateGoal(this.model, npc, goal, threatMap);
       this.npcGoals.set(npc.id, updated);
-      const threatMap = npc.team === 5 ? this._getThreatMap(npc.team) : null;
       return decideTurn(this.model, npc, updated, threatMap);
     });
 
-    // Emit team 5 threat scores for heatmap visualization
-    const map5 = this.threatMaps.get(5 as TeamId);
-    if (map5) {
-      const scores = new Float32Array(this.model.nodeList.length);
-      for (let i = 0; i < scores.length; i++) scores[i] = map5.getScore(i);
-      this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
-        scores,
-        teamColor: TEAM_COLORS[5],
-      });
+    // Emit threat scores for heatmap visualization
+    for (const teamId of AIConfig.ThreatMapTeams as TeamId[]) {
+      const map = this.threatMaps.get(teamId);
+      if (map) {
+        const scores = new Float32Array(this.model.nodeList.length);
+        for (let i = 0; i < scores.length; i++) scores[i] = map.getScore(i);
+        this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
+          scores,
+          teamColor: TEAM_COLORS[teamId],
+        });
+      }
     }
 
     return actions;
@@ -70,7 +73,7 @@ export class TurnManager {
   private _updateThreatMaps(aliveNPCs: Player[], roundNumber: number): void {
     // Only update ThreatMap for team 0
     const activeTeams = new Set<TeamId>(
-      aliveNPCs.filter(n => n.team === 5).map(n => n.team)
+      aliveNPCs.filter(n => (AIConfig.ThreatMapTeams as number[]).includes(n.team)).map(n => n.team)
     );
 
     for (const team of activeTeams) {
@@ -95,7 +98,7 @@ export class TurnManager {
   private getOrInitGoal(npc: Player): NPCGoalState {
     if (!this.npcGoals.has(npc.id)) {
       return {
-        goalNodeId: selectGoalNode(this.model, npc),
+        goalNodeId: selectGoalNode(this.model, npc, null),
         goalSetAtHP: npc.health,
         turnsElapsed: 0,
       };

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -90,6 +90,10 @@ export class TurnManager {
     }
   }
 
+  getThreatMapForTeam(team: TeamId): ThreatMap | null {
+    return this.threatMaps.get(team) ?? null;
+  }
+
   private _getThreatMap(team: TeamId): ThreatMap {
     let map = this.threatMaps.get(team);
     if (!map) {

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -6,6 +6,8 @@ import { NPCGoalState } from './ai/NPCGoalState';
 import { selectGoalNode, updateGoal } from './ai/NPCGoalManager';
 import { ThreatMap } from './ai/ThreatMap';
 import type { TeamId } from '../config/GameConfig';
+import { TEAM_COLORS } from '../config/GameConfig';
+import { GameEventBus, GameEventType } from '../core/GameEventBus';
 
 /**
  * Collects NPC turn decisions for simultaneous round execution.
@@ -16,10 +18,12 @@ export class TurnManager {
   private npcGoals: Map<string, NPCGoalState> = new Map();
   private threatMaps: Map<TeamId, ThreatMap> = new Map();
   private getRoundNumber: () => number;
+  private eventBus: GameEventBus;
 
-  constructor(model: Model, getRoundNumber: () => number) {
+  constructor(model: Model, getRoundNumber: () => number, eventBus: GameEventBus) {
     this.model = model;
     this.getRoundNumber = getRoundNumber;
+    this.eventBus = eventBus;
   }
 
   /**
@@ -41,13 +45,26 @@ export class TurnManager {
     // Update ThreatMaps once per team before any NPC on that team decides
     this._updateThreatMaps(aliveNPCs, roundNumber);
 
-    return aliveNPCs.map(npc => {
+    const actions = aliveNPCs.map(npc => {
       const goal = this.getOrInitGoal(npc);
       const updated = updateGoal(this.model, npc, goal);
       this.npcGoals.set(npc.id, updated);
       const threatMap = npc.team === 5 ? this._getThreatMap(npc.team) : null;
       return decideTurn(this.model, npc, updated, threatMap);
     });
+
+    // Emit team 5 threat scores for heatmap visualization
+    const map5 = this.threatMaps.get(5 as TeamId);
+    if (map5) {
+      const scores = new Float32Array(this.model.nodeList.length);
+      for (let i = 0; i < scores.length; i++) scores[i] = map5.getScore(i);
+      this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
+        scores,
+        teamColor: TEAM_COLORS[5],
+      });
+    }
+
+    return actions;
   }
 
   private _updateThreatMaps(aliveNPCs: Player[], roundNumber: number): void {

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -30,8 +30,9 @@ export class TurnManager {
   /**
    * Returns the intended TurnAction for every alive NPC.
    * Does NOT execute or apply any actions — the caller submits them as a round.
+   * visibleTeam: only emit VIS_THREAT_MAP_UPDATED for this team (avoids 6x emit per round).
    */
-  collectNPCActions(): TurnAction[] {
+  collectNPCActions(visibleTeam: TeamId | null = null): TurnAction[] {
     const aliveNPCs = this.getAliveNPCs();
 
     // Remove goals for NPCs that are no longer alive
@@ -55,21 +56,22 @@ export class TurnManager {
       return decideTurn(this.model, npc, updated, threatMap);
     });
 
-    // Emit threat scores for heatmap visualization
-    const nodeCount = this.model.nodeList.length;
-    for (const teamId of AIConfig.ThreatMapTeams as TeamId[]) {
-      const map = this.threatMaps.get(teamId);
-      if (!map) continue;
-      let scores = this.cachedTeamScores.get(teamId);
-      if (!scores || scores.length !== nodeCount) {
-        scores = new Float32Array(nodeCount);
-        this.cachedTeamScores.set(teamId, scores);
+    // Emit threat scores for heatmap visualization — active team only to avoid N×nodeCount updates
+    if (visibleTeam !== null && (AIConfig.ThreatMapTeams as number[]).includes(visibleTeam)) {
+      const map = this.threatMaps.get(visibleTeam);
+      if (map) {
+        const nodeCount = this.model.nodeList.length;
+        let scores = this.cachedTeamScores.get(visibleTeam);
+        if (!scores || scores.length !== nodeCount) {
+          scores = new Float32Array(nodeCount);
+          this.cachedTeamScores.set(visibleTeam, scores);
+        }
+        for (let i = 0; i < nodeCount; i++) scores[i] = map.getScore(i);
+        this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
+          scores,
+          teamColor: TEAM_COLORS[visibleTeam],
+        });
       }
-      for (let i = 0; i < nodeCount; i++) scores[i] = map.getScore(i);
-      this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
-        scores,
-        teamColor: TEAM_COLORS[teamId],
-      });
     }
 
     return actions;

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -17,6 +17,7 @@ export class TurnManager {
   private model: Model;
   private npcGoals: Map<string, NPCGoalState> = new Map();
   private threatMaps: Map<TeamId, ThreatMap> = new Map();
+  private cachedTeamScores: Map<TeamId, Float32Array> = new Map();
   private getRoundNumber: () => number;
   private eventBus: GameEventBus;
 
@@ -55,23 +56,26 @@ export class TurnManager {
     });
 
     // Emit threat scores for heatmap visualization
+    const nodeCount = this.model.nodeList.length;
     for (const teamId of AIConfig.ThreatMapTeams as TeamId[]) {
       const map = this.threatMaps.get(teamId);
-      if (map) {
-        const scores = new Float32Array(this.model.nodeList.length);
-        for (let i = 0; i < scores.length; i++) scores[i] = map.getScore(i);
-        this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
-          scores,
-          teamColor: TEAM_COLORS[teamId],
-        });
+      if (!map) continue;
+      let scores = this.cachedTeamScores.get(teamId);
+      if (!scores || scores.length !== nodeCount) {
+        scores = new Float32Array(nodeCount);
+        this.cachedTeamScores.set(teamId, scores);
       }
+      for (let i = 0; i < nodeCount; i++) scores[i] = map.getScore(i);
+      this.eventBus.emit(GameEventType.VIS_THREAT_MAP_UPDATED, {
+        scores,
+        teamColor: TEAM_COLORS[teamId],
+      });
     }
 
     return actions;
   }
 
   private _updateThreatMaps(aliveNPCs: Player[], roundNumber: number): void {
-    // Only update ThreatMap for team 0
     const activeTeams = new Set<TeamId>(
       aliveNPCs.filter(n => (AIConfig.ThreatMapTeams as number[]).includes(n.team)).map(n => n.team)
     );

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -1,6 +1,5 @@
 import { Model } from '../model/model';
 import { TurnAction } from '../schema/types';
-import { HUMAN_PLAYER_ID } from '../config/GameConfig';
 import { decideTurn } from './ai/NPCBrain';
 
 /**
@@ -24,6 +23,6 @@ export class TurnManager {
 
   private getAliveNPCs() {
     return Array.from(this.model.players.values())
-      .filter(p => p.isNPC && p.isAlive && p.id !== HUMAN_PLAYER_ID);
+      .filter(p => p.isNPC && p.isAlive);
   }
 }

--- a/src/logic/TurnManager.ts
+++ b/src/logic/TurnManager.ts
@@ -4,6 +4,8 @@ import { TurnAction } from '../schema/types';
 import { decideTurn } from './ai/NPCBrain';
 import { NPCGoalState } from './ai/NPCGoalState';
 import { selectGoalNode, updateGoal } from './ai/NPCGoalManager';
+import { ThreatMap } from './ai/ThreatMap';
+import type { TeamId } from '../config/GameConfig';
 
 /**
  * Collects NPC turn decisions for simultaneous round execution.
@@ -12,9 +14,12 @@ import { selectGoalNode, updateGoal } from './ai/NPCGoalManager';
 export class TurnManager {
   private model: Model;
   private npcGoals: Map<string, NPCGoalState> = new Map();
+  private threatMaps: Map<TeamId, ThreatMap> = new Map();
+  private getRoundNumber: () => number;
 
-  constructor(model: Model) {
+  constructor(model: Model, getRoundNumber: () => number) {
     this.model = model;
+    this.getRoundNumber = getRoundNumber;
   }
 
   /**
@@ -31,12 +36,43 @@ export class TurnManager {
       }
     }
 
+    const roundNumber = this.getRoundNumber();
+
+    // Update ThreatMaps once per team before any NPC on that team decides
+    this._updateThreatMaps(aliveNPCs, roundNumber);
+
     return aliveNPCs.map(npc => {
       const goal = this.getOrInitGoal(npc);
       const updated = updateGoal(this.model, npc, goal);
       this.npcGoals.set(npc.id, updated);
-      return decideTurn(this.model, npc, updated);
+      const threatMap = npc.team === 5 ? this._getThreatMap(npc.team) : null;
+      return decideTurn(this.model, npc, updated, threatMap);
     });
+  }
+
+  private _updateThreatMaps(aliveNPCs: Player[], roundNumber: number): void {
+    // Only update ThreatMap for team 0
+    const activeTeams = new Set<TeamId>(
+      aliveNPCs.filter(n => n.team === 5).map(n => n.team)
+    );
+
+    for (const team of activeTeams) {
+      let map = this.threatMaps.get(team);
+      if (!map) {
+        map = new ThreatMap(team, this.model.nodeList.length);
+        this.threatMaps.set(team, map);
+      }
+      map.observeAndRescore(this.model, roundNumber);
+    }
+  }
+
+  private _getThreatMap(team: TeamId): ThreatMap {
+    let map = this.threatMaps.get(team);
+    if (!map) {
+      map = new ThreatMap(team, this.model.nodeList.length);
+      this.threatMaps.set(team, map);
+    }
+    return map;
   }
 
   private getOrInitGoal(npc: Player): NPCGoalState {

--- a/src/logic/ai/NPCBrain.ts
+++ b/src/logic/ai/NPCBrain.ts
@@ -28,22 +28,28 @@ export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnA
     }
   }
 
-  // 2. Calculate facing angle toward nearest enemy from chosen node
+  // 2. Calculate facing angle: prefer nearest visible enemy, else keep current angle
   const moveToNode = model.nodeList[moveToNodeId];
   let facingAngle = npc.angle;
 
   if (enemies.length > 0) {
-    let nearestEnemy: Player | undefined;
-    let nearestDist = Infinity;
-    for (const enemy of enemies) {
-      const dist = model.getNodeDistance(moveToNode, enemy.node);
-      if (dist < nearestDist) {
-        nearestDist = dist;
-        nearestEnemy = enemy;
+    const visibleNodes = model.getVisibleNodesAtAngle(moveToNode, npc.angle, PlayerConfig.MaxViewDistance);
+    const visibleNodeIds = new Set(visibleNodes.map(n => n.id));
+    const visibleEnemies = enemies.filter(e => visibleNodeIds.has(e.node.id));
+
+    if (visibleEnemies.length > 0) {
+      let nearestEnemy: Player | undefined;
+      let nearestDist = Infinity;
+      for (const enemy of visibleEnemies) {
+        const dist = model.getNodeDistance(moveToNode, enemy.node);
+        if (dist < nearestDist) {
+          nearestDist = dist;
+          nearestEnemy = enemy;
+        }
       }
-    }
-    if (nearestEnemy) {
-      facingAngle = model.getAngleBetweenNodes(moveToNode, nearestEnemy.node);
+      if (nearestEnemy) {
+        facingAngle = model.getAngleBetweenNodes(moveToNode, nearestEnemy.node);
+      }
     }
   }
 
@@ -54,5 +60,6 @@ export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnA
     playerId: npc.id,
     moveToNodeId,
     shotAtNodeId,
+    angle: facingAngle,
   };
 }

--- a/src/logic/ai/NPCBrain.ts
+++ b/src/logic/ai/NPCBrain.ts
@@ -1,16 +1,17 @@
 import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
-import { PlayerConfig } from '../../config/GameConfig';
+import { PlayerConfig, AIConfig } from '../../config/GameConfig';
 import { TurnAction } from '../../schema/types';
 import { selectShotTarget } from './ShotSelector';
 import { isNodeOccupied } from './NPCGoalManager';
 import { NPCGoalState } from './NPCGoalState';
+import { ThreatMap } from './ThreatMap';
 
 /**
  * Top-level NPC decision maker.
  * Produces a complete TurnAction for one NPC, following the given goal state.
  */
-export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnAction {
+export function decideTurn(model: Model, npc: Player, goal: NPCGoalState, threatMap: ThreatMap | null): TurnAction {
   const enemies = model.getEnemyPlayers(npc.id);
 
   // 1. Follow path toward goal node, advance one step
@@ -28,7 +29,7 @@ export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnA
     }
   }
 
-  // 2. Calculate facing angle: prefer nearest visible enemy, else keep current angle
+  // 2. Calculate facing angle: prefer nearest visible enemy, else use ThreatMap
   const moveToNode = model.nodeList[moveToNodeId];
   let facingAngle = npc.angle;
 
@@ -38,6 +39,7 @@ export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnA
     const visibleEnemies = enemies.filter(e => visibleNodeIds.has(e.node.id));
 
     if (visibleEnemies.length > 0) {
+      // Highest priority: face the nearest visible enemy
       let nearestEnemy: Player | undefined;
       let nearestDist = Infinity;
       for (const enemy of visibleEnemies) {
@@ -50,6 +52,13 @@ export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnA
       if (nearestEnemy) {
         facingAngle = model.getAngleBetweenNodes(moveToNode, nearestEnemy.node);
       }
+    } else if (AIConfig.ThreatMapAngleEnabled && threatMap !== null) {
+      // No visible enemy: face the highest-threat node outside current FOV
+      const target = threatMap.getHighestThreatNodeFrom(moveToNodeId, model, visibleNodeIds);
+      if (target !== null) {
+        facingAngle = model.getAngleBetweenNodes(moveToNode, model.nodeList[target]);
+      }
+      // If no threat candidate, keep previous angle (existing behaviour)
     }
   }
 

--- a/src/logic/ai/NPCBrain.ts
+++ b/src/logic/ai/NPCBrain.ts
@@ -2,36 +2,34 @@ import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
 import { PlayerConfig } from '../../config/GameConfig';
 import { TurnAction } from '../../schema/types';
-import { scoreNode } from './NodeScorer';
 import { selectShotTarget } from './ShotSelector';
+import { isNodeOccupied } from './NPCGoalManager';
+import { NPCGoalState } from './NPCGoalState';
 
 /**
  * Top-level NPC decision maker.
- * Produces a complete TurnAction for one NPC.
+ * Produces a complete TurnAction for one NPC, following the given goal state.
  */
-export function decideTurn(model: Model, npc: Player): TurnAction {
+export function decideTurn(model: Model, npc: Player, goal: NPCGoalState): TurnAction {
   const enemies = model.getEnemyPlayers(npc.id);
 
-  // 1. Evaluate candidate move nodes: reachable within MoveRange + current (stay)
-  const reachable = model.getReachableNodes(npc.node.id, PlayerConfig.MoveRange);
-  const candidates = [npc.node.id, ...reachable];
+  // 1. Follow path toward goal node, advance one step
+  let moveToNodeId = npc.node.id;
 
-  let bestNodeId = npc.node.id;
-  let bestScore = -Infinity;
-
-  for (const nodeId of candidates) {
-    // Skip nodes occupied by other alive players
-    if (isNodeOccupied(model, nodeId, npc.id)) continue;
-
-    const score = scoreNode(model, npc, nodeId, enemies);
-    if (score > bestScore) {
-      bestScore = score;
-      bestNodeId = nodeId;
+  if (goal.goalNodeId !== npc.node.id) {
+    const path = model.getPathToNode(npc.node.id, goal.goalNodeId, Infinity);
+    // path = [currentNode, step1, step2, ...]; take MoveRange steps forward
+    if (path && path.length > 1) {
+      const nextIndex = Math.min(PlayerConfig.MoveRange, path.length - 1);
+      const candidate = path[nextIndex];
+      if (!isNodeOccupied(model, candidate, npc.id)) {
+        moveToNodeId = candidate;
+      }
     }
   }
 
-  // 2. Calculate facing angle toward nearest visible enemy from chosen node
-  const moveToNode = model.nodeList[bestNodeId];
+  // 2. Calculate facing angle toward nearest enemy from chosen node
+  const moveToNode = model.nodeList[moveToNodeId];
   let facingAngle = npc.angle;
 
   if (enemies.length > 0) {
@@ -54,15 +52,7 @@ export function decideTurn(model: Model, npc: Player): TurnAction {
 
   return {
     playerId: npc.id,
-    moveToNodeId: bestNodeId,
+    moveToNodeId,
     shotAtNodeId,
   };
-}
-
-function isNodeOccupied(model: Model, nodeId: number, excludeId: string): boolean {
-  for (const [id, player] of model.players) {
-    if (id === excludeId) continue;
-    if (player.isAlive && player.node.id === nodeId) return true;
-  }
-  return false;
 }

--- a/src/logic/ai/NPCGoalManager.ts
+++ b/src/logic/ai/NPCGoalManager.ts
@@ -1,0 +1,51 @@
+import { Model } from '../../model/model';
+import { Player } from '../../model/Player';
+import { AIConfig } from '../../config/GameConfig';
+import { scoreNode } from './NodeScorer';
+import { NPCGoalState } from './NPCGoalState';
+
+export function isNodeOccupied(model: Model, nodeId: number, excludeId: string): boolean {
+  for (const [id, player] of model.players) {
+    if (id === excludeId) continue;
+    if (player.isAlive && player.node.id === nodeId) return true;
+  }
+  return false;
+}
+
+export function selectGoalNode(model: Model, npc: Player): number {
+  const enemies = model.getEnemyPlayers(npc.id);
+  const reachable = model.getReachableNodes(npc.node.id, AIConfig.GoalSearchRadius);
+  const candidates = Array.from(reachable);
+
+  if (candidates.length === 0) return npc.node.id;
+
+  let bestNodeId = npc.node.id;
+  let bestScore = -Infinity;
+
+  for (const nodeId of candidates) {
+    if (isNodeOccupied(model, nodeId, npc.id)) continue;
+    const score = scoreNode(model, npc, nodeId, enemies);
+    if (score > bestScore) {
+      bestScore = score;
+      bestNodeId = nodeId;
+    }
+  }
+
+  return bestNodeId;
+}
+
+export function updateGoal(model: Model, npc: Player, goal: NPCGoalState): NPCGoalState {
+  const arrivedAtGoal = npc.node.id === goal.goalNodeId;
+  const timedOut = goal.turnsElapsed >= AIConfig.GoalTimeoutTurns;
+  const hpDropped = npc.health < goal.goalSetAtHP - AIConfig.GoalHPChangeThreshold;
+
+  if (arrivedAtGoal || timedOut || hpDropped) {
+    return {
+      goalNodeId: selectGoalNode(model, npc),
+      goalSetAtHP: npc.health,
+      turnsElapsed: 0,
+    };
+  }
+
+  return { ...goal, turnsElapsed: goal.turnsElapsed + 1 };
+}

--- a/src/logic/ai/NPCGoalManager.ts
+++ b/src/logic/ai/NPCGoalManager.ts
@@ -3,6 +3,7 @@ import { Player } from '../../model/Player';
 import { AIConfig } from '../../config/GameConfig';
 import { scoreNode } from './NodeScorer';
 import { NPCGoalState } from './NPCGoalState';
+import { ThreatMap } from './ThreatMap';
 
 export function isNodeOccupied(model: Model, nodeId: number, excludeId: string): boolean {
   for (const [id, player] of model.players) {
@@ -12,7 +13,7 @@ export function isNodeOccupied(model: Model, nodeId: number, excludeId: string):
   return false;
 }
 
-export function selectGoalNode(model: Model, npc: Player): number {
+export function selectGoalNode(model: Model, npc: Player, threatMap: ThreatMap | null): number {
   const enemies = model.getEnemyPlayers(npc.id);
   const reachable = model.getReachableNodes(npc.node.id, AIConfig.GoalSearchRadius);
   const candidates = Array.from(reachable);
@@ -24,7 +25,8 @@ export function selectGoalNode(model: Model, npc: Player): number {
 
   for (const nodeId of candidates) {
     if (isNodeOccupied(model, nodeId, npc.id)) continue;
-    const score = scoreNode(model, npc, nodeId, enemies);
+    const score = scoreNode(model, npc, nodeId, enemies)
+      + (threatMap ? threatMap.getScore(nodeId) * AIConfig.ThreatMapGoalBonus : 0);
     if (score > bestScore) {
       bestScore = score;
       bestNodeId = nodeId;
@@ -34,14 +36,14 @@ export function selectGoalNode(model: Model, npc: Player): number {
   return bestNodeId;
 }
 
-export function updateGoal(model: Model, npc: Player, goal: NPCGoalState): NPCGoalState {
+export function updateGoal(model: Model, npc: Player, goal: NPCGoalState, threatMap: ThreatMap | null): NPCGoalState {
   const arrivedAtGoal = npc.node.id === goal.goalNodeId;
   const timedOut = goal.turnsElapsed >= AIConfig.GoalTimeoutTurns;
   const hpDropped = npc.health < goal.goalSetAtHP - AIConfig.GoalHPChangeThreshold;
 
   if (arrivedAtGoal || timedOut || hpDropped) {
     return {
-      goalNodeId: selectGoalNode(model, npc),
+      goalNodeId: selectGoalNode(model, npc, threatMap),
       goalSetAtHP: npc.health,
       turnsElapsed: 0,
     };

--- a/src/logic/ai/NPCGoalManager.ts
+++ b/src/logic/ai/NPCGoalManager.ts
@@ -20,12 +20,14 @@ export function selectGoalNode(model: Model, npc: Player, threatMap: ThreatMap |
 
   if (candidates.length === 0) return npc.node.id;
 
+  const teamVisibleNodeIds = model.getTeamVisibleNodes(npc.id);
+
   let bestNodeId = npc.node.id;
   let bestScore = -Infinity;
 
   for (const nodeId of candidates) {
     if (isNodeOccupied(model, nodeId, npc.id)) continue;
-    const score = scoreNode(model, npc, nodeId, enemies)
+    const score = scoreNode(model, npc, nodeId, enemies, threatMap, teamVisibleNodeIds)
       + (threatMap ? threatMap.getScore(nodeId) * AIConfig.ThreatMapGoalBonus : 0);
     if (score > bestScore) {
       bestScore = score;

--- a/src/logic/ai/NPCGoalState.ts
+++ b/src/logic/ai/NPCGoalState.ts
@@ -1,0 +1,5 @@
+export interface NPCGoalState {
+  goalNodeId: number;
+  goalSetAtHP: number;
+  turnsElapsed: number;
+}

--- a/src/logic/ai/NodeScorer.ts
+++ b/src/logic/ai/NodeScorer.ts
@@ -1,65 +1,104 @@
 import { Model } from '../../model/model';
 import { Player } from '../../model/Player';
-import { AIConfig } from '../../config/GameConfig';
-import { MapConfig } from '../../config/GameConfig';
+import { AIConfig, MapConfig } from '../../config/GameConfig';
+import { ThreatMap } from './ThreatMap';
 
 /**
- * Evaluates a candidate move node for an NPC.
- * Pure function: reads from Model, returns a numeric score.
+ * Evaluates a candidate move node for an NPC using ThreatMap-based estimation.
+ * The function does NOT directly inspect enemies the team cannot see — it relies on
+ *   - `threatMap`: per-node enemy presence probability (0..1) shared across the team
+ *   - `teamVisibleNodeIds`: nodes any teammate is currently looking at
+ * Enemies present in `enemies` are only used when their node is in `teamVisibleNodeIds`.
  */
 export function scoreNode(
   model: Model,
   npc: Player,
   candidateNodeId: number,
-  enemies: Player[]
+  enemies: Player[],
+  threatMap: ThreatMap | null,
+  teamVisibleNodeIds: Set<number>,
 ): number {
   let score = 0;
   const candidateNode = model.nodeList[candidateNodeId];
   const gridSize = MapConfig.NodesInGridSize;
+  const nodeCount = model.nodeList.length;
 
   // 1. Cover score: fewer graph edges = more walls around this node
   const edgeCount = model.Edges.List[candidateNodeId]?.length ?? 0;
-  const coverScore = 4 - edgeCount; // max 4 directions, so 0-4 walls
+  const coverScore = 4 - edgeCount;
   const coverWeight = npc.health < AIConfig.RetreatHPThreshold
     ? AIConfig.CoverWeight * AIConfig.RetreatCoverMultiplier
     : AIConfig.CoverWeight;
   score += coverScore * coverWeight;
 
-  // 2. Enemy LOS exposure & ambush potential
+  // 2. Enemy LOS exposure penalty (estimation-based)
+  //    a) Threat-weighted exposure from unobserved nodes that may hide an enemy
+  if (threatMap) {
+    for (let nid = 0; nid < nodeCount; nid++) {
+      const threat = threatMap.getScore(nid);
+      if (threat <= AIConfig.ScorerThreatExposureMin) continue;
+      if (teamVisibleNodeIds.has(nid)) continue; // observed nodes handled below
+      if (model.hasLineOfSight(model.nodeList[nid], candidateNode)) {
+        score += AIConfig.EnemyLOSPenalty * threat;
+      }
+    }
+  }
+  //    b) Confirmed enemies the team is currently looking at — full penalty
   for (const enemy of enemies) {
-    const enemySeesCandidate = model.hasLineOfSight(enemy.node, candidateNode);
-    const npcSeesEnemy = model.hasLineOfSight(candidateNode, enemy.node);
-
-    if (enemySeesCandidate) {
+    if (!teamVisibleNodeIds.has(enemy.node.id)) continue;
+    if (model.hasLineOfSight(enemy.node, candidateNode)) {
       score += AIConfig.EnemyLOSPenalty;
     }
+  }
 
-    // 3. Ambush: NPC can see enemy but enemy can't see NPC
-    if (npcSeesEnemy && !enemySeesCandidate) {
+  // 3. Ambush bonus — only against enemies the team currently sees
+  for (const enemy of enemies) {
+    if (!teamVisibleNodeIds.has(enemy.node.id)) continue;
+    if (model.hasLineOfSight(candidateNode, enemy.node)) {
       score += AIConfig.AmbushBonus;
     }
   }
 
-  // 4. Distance to nearest enemy (Manhattan distance on grid)
-  let minDistance = Infinity;
+  // 4. Distance score — prefer the nearest visible enemy, else threat-weighted centroid
+  const candidateCol = Math.floor(candidateNodeId / gridSize);
+  const candidateRow = candidateNodeId % gridSize;
+
+  let targetDist = Infinity;
+
+  let minVisDist = Infinity;
   for (const enemy of enemies) {
-    const candidateCol = Math.floor(candidateNodeId / gridSize);
-    const candidateRow = candidateNodeId % gridSize;
+    if (!teamVisibleNodeIds.has(enemy.node.id)) continue;
     const enemyCol = Math.floor(enemy.node.id / gridSize);
     const enemyRow = enemy.node.id % gridSize;
-    const dist = Math.abs(candidateCol - enemyCol) + Math.abs(candidateRow - enemyRow);
-    if (dist < minDistance) {
-      minDistance = dist;
+    const d = Math.abs(candidateCol - enemyCol) + Math.abs(candidateRow - enemyRow);
+    if (d < minVisDist) minVisDist = d;
+  }
+
+  if (minVisDist !== Infinity) {
+    targetDist = minVisDist;
+  } else if (threatMap) {
+    let sumW = 0, sumWX = 0, sumWY = 0;
+    for (let nid = 0; nid < nodeCount; nid++) {
+      const t = threatMap.getScore(nid);
+      if (t <= AIConfig.ScorerThreatExposureMin) continue;
+      const col = Math.floor(nid / gridSize);
+      const row = nid % gridSize;
+      sumW += t;
+      sumWX += t * col;
+      sumWY += t * row;
+    }
+    if (sumW > 0) {
+      const cx = sumWX / sumW;
+      const cy = sumWY / sumW;
+      targetDist = Math.abs(candidateCol - cx) + Math.abs(candidateRow - cy);
     }
   }
 
-  if (minDistance !== Infinity) {
+  if (targetDist !== Infinity) {
     if (npc.health < AIConfig.RetreatHPThreshold) {
-      // Low HP: prefer distance from enemies (invert weight)
-      score += minDistance * Math.abs(AIConfig.DistanceWeight);
+      score += targetDist * Math.abs(AIConfig.DistanceWeight);
     } else {
-      // Normal: prefer closer to enemies
-      score += minDistance * AIConfig.DistanceWeight;
+      score += targetDist * AIConfig.DistanceWeight;
     }
   }
 

--- a/src/logic/ai/ThreatMap.ts
+++ b/src/logic/ai/ThreatMap.ts
@@ -6,10 +6,10 @@ import type { TeamId } from '../../config/GameConfig';
  * Tracks enemy presence probability for a single team.
  * Updated once per round before NPC decisions; read-only during decideTurn.
  *
- * Score model:
- *   - Nodes observed this round: score = 1 if enemy present, 0 if clear
- *   - Previously observed nodes: exponential decay in time + BFS diffusion from sighting sources
- *   - Long-unobserved nodes: ambient score rises up to ThreatAmbientCap
+ * Score model (cumulative diffusion):
+ *   - Each round: scores are multiplied by ThreatAccumulationDecay, then BFS-diffused outward
+ *   - Nodes observed this round: overwritten with 1.0 (enemy present) or 0.0 (clear)
+ *   - Effect: threat "ripples" outward from sightings and fades over time
  */
 export class ThreatMap {
   readonly team: TeamId;
@@ -30,7 +30,7 @@ export class ThreatMap {
     this.team = team;
     this.lastSeenRound = new Float64Array(nodeCount).fill(-Infinity);
     this.lastSeenHadEnemy = new Uint8Array(nodeCount);
-    this.score = new Float32Array(nodeCount);
+    this.score = new Float32Array(nodeCount).fill(1);
     this.confirmedDeadAt = new Set();
   }
 
@@ -118,36 +118,36 @@ export class ThreatMap {
 
   private _rescore(model: Model, roundNumber: number): void {
     const nodeCount = model.nodeList.length;
-    const tau = AIConfig.ThreatTau;
+    const decay = AIConfig.ThreatAccumulationDecay;
+    const spreadFactor = AIConfig.ThreatSpreadFactor;
     const sigma = AIConfig.ThreatSigma;
     const maxSteps = AIConfig.ThreatMaxDiffusionSteps;
-    const ambientCap = AIConfig.ThreatAmbientCap;
 
-    // --- Pass 1: compute source scores ---
-    // sourceScore[id] = how confident we are that a living enemy was last seen here
-    const sourceScore = new Float32Array(nodeCount);
+    // --- Pass 0: decay accumulated scores from previous round ---
     for (let id = 0; id < nodeCount; id++) {
-      if (this.confirmedDeadAt.has(id)) continue;
-      if (!this.lastSeenHadEnemy[id]) continue;
-      const dt = roundNumber - this.lastSeenRound[id];
-      sourceScore[id] = Math.exp(-dt / tau);
+      this.score[id] *= decay;
     }
 
-    // --- Pass 2: BFS diffusion from each source ---
-    // diffused[id] = max over all sources j of: sourceScore[j] * exp(-bfsDist(id,j) / sigma)
+    // --- Pass 1: overwrite observed nodes with ground-truth values ---
+    for (let id = 0; id < nodeCount; id++) {
+      if (this.lastSeenRound[id] !== roundNumber) continue;
+      this.score[id] = this.lastSeenHadEnemy[id] ? 1.0 : 0.0;
+    }
+
+    // --- Pass 2: BFS diffusion — score[] is the wave source ---
     const diffused = new Float32Array(nodeCount);
 
     for (let srcId = 0; srcId < nodeCount; srcId++) {
-      const src = sourceScore[srcId];
+      const src = this.score[srcId];
       if (src <= 0) continue;
+      if (this.confirmedDeadAt.has(srcId)) continue;
 
-      // BFS outward from srcId up to maxSteps
       const visited = new Set<number>([srcId]);
       let frontier = [srcId];
       let dist = 0;
 
       while (frontier.length > 0 && dist <= maxSteps) {
-        const contribution = src * Math.exp(-dist / sigma);
+        const contribution = src * spreadFactor * Math.exp(-dist / sigma);
         for (const nid of frontier) {
           if (contribution > diffused[nid]) {
             diffused[nid] = contribution;
@@ -169,23 +169,13 @@ export class ThreatMap {
       }
     }
 
-    // --- Pass 3: combine with ambient + apply current-round overrides ---
+    // --- Pass 3: merge diffusion, clamp, re-apply observed overrides ---
     for (let id = 0; id < nodeCount; id++) {
-      const dt = roundNumber - this.lastSeenRound[id];
-      const isCurrentlyObserved = this.lastSeenRound[id] === roundNumber;
-
-      if (isCurrentlyObserved) {
-        // Known state this round: enemy present → 1, clear → 0
+      if (this.lastSeenRound[id] === roundNumber) {
         this.score[id] = this.lastSeenHadEnemy[id] ? 1.0 : 0.0;
-        continue;
+      } else {
+        this.score[id] = Math.min(1.0, Math.max(this.score[id], diffused[id]));
       }
-
-      // Ambient: rises the longer a node goes unobserved
-      const ambientScore = dt === Infinity
-        ? ambientCap
-        : Math.min(ambientCap, 1 - Math.exp(-dt / tau));
-
-      this.score[id] = Math.max(diffused[id], ambientScore);
     }
   }
 }

--- a/src/logic/ai/ThreatMap.ts
+++ b/src/logic/ai/ThreatMap.ts
@@ -1,0 +1,191 @@
+import { Model } from '../../model/model';
+import { AIConfig } from '../../config/GameConfig';
+import type { TeamId } from '../../config/GameConfig';
+
+/**
+ * Tracks enemy presence probability for a single team.
+ * Updated once per round before NPC decisions; read-only during decideTurn.
+ *
+ * Score model:
+ *   - Nodes observed this round: score = 1 if enemy present, 0 if clear
+ *   - Previously observed nodes: exponential decay in time + BFS diffusion from sighting sources
+ *   - Long-unobserved nodes: ambient score rises up to ThreatAmbientCap
+ */
+export class ThreatMap {
+  readonly team: TeamId;
+
+  /** Last round number when each node was observed by any teammate. -Infinity = never. */
+  private lastSeenRound: Float64Array;
+
+  /** Whether an enemy was present when each node was last observed. */
+  private lastSeenHadEnemy: Uint8Array;
+
+  /** Cached threat scores, recomputed each round. */
+  private score: Float32Array;
+
+  /** Nodes where an enemy death was confirmed (suppressed as diffusion sources). */
+  private confirmedDeadAt: Set<number>;
+
+  constructor(team: TeamId, nodeCount: number) {
+    this.team = team;
+    this.lastSeenRound = new Float64Array(nodeCount).fill(-Infinity);
+    this.lastSeenHadEnemy = new Uint8Array(nodeCount);
+    this.score = new Float32Array(nodeCount);
+    this.confirmedDeadAt = new Set();
+  }
+
+  /**
+   * Called once per round, before decideTurn for any NPC on this team.
+   * 1. Observes current team FOV and records sightings.
+   * 2. Marks confirmed enemy deaths.
+   * 3. Recomputes all threat scores.
+   */
+  observeAndRescore(model: Model, roundNumber: number): void {
+    this._observe(model, roundNumber);
+    this._rescore(model, roundNumber);
+  }
+
+  /** Returns the threat score [0..1] for a given node. */
+  getScore(nodeId: number): number {
+    return this.score[nodeId] ?? 0;
+  }
+
+  /**
+   * Returns the node ID with the highest threat score reachable from fromNodeId,
+   * excluding nodes currently visible (already known safe/threatened).
+   * Returns null if no candidate found.
+   */
+  getHighestThreatNodeFrom(
+    fromNodeId: number,
+    model: Model,
+    currentlyVisible: Set<number>,
+  ): number | null {
+    const candidates = model.getReachableNodes(fromNodeId, AIConfig.ThreatMapMaxLookDistance);
+    let bestId: number | null = null;
+    let bestScore = -1;
+
+    for (const nodeId of candidates) {
+      if (currentlyVisible.has(nodeId)) continue;
+      const s = this.score[nodeId] ?? 0;
+      if (s > bestScore) {
+        bestScore = s;
+        bestId = nodeId;
+      }
+    }
+
+    return bestId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _observe(model: Model, roundNumber: number): void {
+    // Get a representative alive teammate to query team visibility
+    let repId: string | undefined;
+    for (const [id, p] of model.players) {
+      if (p.team === this.team && p.isAlive) {
+        repId = id;
+        break;
+      }
+    }
+    if (!repId) return;
+
+    const visibleNodeIds = model.getTeamVisibleNodes(repId);
+
+    // Collect enemy player node IDs that are alive
+    const enemyNodeIds = new Set<number>();
+    for (const [, p] of model.players) {
+      if (p.team !== this.team && p.isAlive) {
+        enemyNodeIds.add(p.node.id);
+      }
+    }
+
+    // Record dead enemies whose bodies are visible — suppress as diffusion source
+    for (const [, p] of model.players) {
+      if (p.team !== this.team && !p.isAlive && visibleNodeIds.has(p.node.id)) {
+        this.confirmedDeadAt.add(p.node.id);
+        this.lastSeenHadEnemy[p.node.id] = 0;
+      }
+    }
+
+    // Update lastSeen for all currently visible nodes
+    for (const nodeId of visibleNodeIds) {
+      this.lastSeenRound[nodeId] = roundNumber;
+      this.lastSeenHadEnemy[nodeId] = enemyNodeIds.has(nodeId) ? 1 : 0;
+    }
+  }
+
+  private _rescore(model: Model, roundNumber: number): void {
+    const nodeCount = model.nodeList.length;
+    const tau = AIConfig.ThreatTau;
+    const sigma = AIConfig.ThreatSigma;
+    const maxSteps = AIConfig.ThreatMaxDiffusionSteps;
+    const ambientCap = AIConfig.ThreatAmbientCap;
+
+    // --- Pass 1: compute source scores ---
+    // sourceScore[id] = how confident we are that a living enemy was last seen here
+    const sourceScore = new Float32Array(nodeCount);
+    for (let id = 0; id < nodeCount; id++) {
+      if (this.confirmedDeadAt.has(id)) continue;
+      if (!this.lastSeenHadEnemy[id]) continue;
+      const dt = roundNumber - this.lastSeenRound[id];
+      sourceScore[id] = Math.exp(-dt / tau);
+    }
+
+    // --- Pass 2: BFS diffusion from each source ---
+    // diffused[id] = max over all sources j of: sourceScore[j] * exp(-bfsDist(id,j) / sigma)
+    const diffused = new Float32Array(nodeCount);
+
+    for (let srcId = 0; srcId < nodeCount; srcId++) {
+      const src = sourceScore[srcId];
+      if (src <= 0) continue;
+
+      // BFS outward from srcId up to maxSteps
+      const visited = new Set<number>([srcId]);
+      let frontier = [srcId];
+      let dist = 0;
+
+      while (frontier.length > 0 && dist <= maxSteps) {
+        const contribution = src * Math.exp(-dist / sigma);
+        for (const nid of frontier) {
+          if (contribution > diffused[nid]) {
+            diffused[nid] = contribution;
+          }
+        }
+        dist++;
+        const next: number[] = [];
+        for (const nid of frontier) {
+          const neighbors = model.Edges.List[nid];
+          if (!neighbors) continue;
+          for (const nb of neighbors) {
+            if (!visited.has(nb)) {
+              visited.add(nb);
+              next.push(nb);
+            }
+          }
+        }
+        frontier = next;
+      }
+    }
+
+    // --- Pass 3: combine with ambient + apply current-round overrides ---
+    for (let id = 0; id < nodeCount; id++) {
+      const dt = roundNumber - this.lastSeenRound[id];
+      const isCurrentlyObserved = this.lastSeenRound[id] === roundNumber;
+
+      if (isCurrentlyObserved) {
+        // Known state this round: enemy present → 1, clear → 0
+        this.score[id] = this.lastSeenHadEnemy[id] ? 1.0 : 0.0;
+        continue;
+      }
+
+      // Ambient: rises the longer a node goes unobserved
+      const ambientScore = dt === Infinity
+        ? ambientCap
+        : Math.min(ambientCap, 1 - Math.exp(-dt / tau));
+
+      this.score[id] = Math.max(diffused[id], ambientScore);
+    }
+  }
+}

--- a/src/logic/ai/ThreatMap.ts
+++ b/src/logic/ai/ThreatMap.ts
@@ -26,12 +26,22 @@ export class ThreatMap {
   /** Nodes where an enemy death was confirmed (suppressed as diffusion sources). */
   private confirmedDeadAt: Set<number>;
 
+  /** Reusable BFS buffers — cleared and reused each _rescore call to avoid per-iteration allocations. */
+  private bfsDiffused: Float32Array;
+  private bfsVisited: Uint8Array;
+  private bfsFrontier: number[];
+  private bfsNext: number[];
+
   constructor(team: TeamId, nodeCount: number) {
     this.team = team;
     this.lastSeenRound = new Float64Array(nodeCount).fill(-Infinity);
     this.lastSeenHadEnemy = new Uint8Array(nodeCount);
     this.score = new Float32Array(nodeCount).fill(1);
     this.confirmedDeadAt = new Set();
+    this.bfsDiffused = new Float32Array(nodeCount);
+    this.bfsVisited = new Uint8Array(nodeCount);
+    this.bfsFrontier = [];
+    this.bfsNext = [];
   }
 
   /**
@@ -135,37 +145,41 @@ export class ThreatMap {
     }
 
     // --- Pass 2: BFS diffusion — score[] is the wave source ---
-    const diffused = new Float32Array(nodeCount);
+    const diffused = this.bfsDiffused;
+    diffused.fill(0);
 
     for (let srcId = 0; srcId < nodeCount; srcId++) {
       const src = this.score[srcId];
       if (src <= 0) continue;
       if (this.confirmedDeadAt.has(srcId)) continue;
 
-      const visited = new Set<number>([srcId]);
-      let frontier = [srcId];
+      // Reuse frontier/visited buffers — clear before use
+      this.bfsVisited.fill(0);
+      this.bfsFrontier.length = 0;
+      this.bfsVisited[srcId] = 1;
+      this.bfsFrontier.push(srcId);
       let dist = 0;
 
-      while (frontier.length > 0 && dist <= maxSteps) {
+      while (this.bfsFrontier.length > 0 && dist <= maxSteps) {
         const contribution = src * spreadFactor * Math.exp(-dist / sigma);
-        for (const nid of frontier) {
-          if (contribution > diffused[nid]) {
-            diffused[nid] = contribution;
-          }
+        for (const nid of this.bfsFrontier) {
+          if (contribution > diffused[nid]) diffused[nid] = contribution;
         }
         dist++;
-        const next: number[] = [];
-        for (const nid of frontier) {
+        this.bfsNext.length = 0;
+        for (const nid of this.bfsFrontier) {
           const neighbors = model.Edges.List[nid];
           if (!neighbors) continue;
           for (const nb of neighbors) {
-            if (!visited.has(nb)) {
-              visited.add(nb);
-              next.push(nb);
+            if (!this.bfsVisited[nb]) {
+              this.bfsVisited[nb] = 1;
+              this.bfsNext.push(nb);
             }
           }
         }
-        frontier = next;
+        const tmp = this.bfsFrontier;
+        this.bfsFrontier = this.bfsNext;
+        this.bfsNext = tmp;
       }
     }
 

--- a/src/model/Player.ts
+++ b/src/model/Player.ts
@@ -1,7 +1,7 @@
 import { Node } from './node';
 import { Entity, EntityType } from './entities/Entity';
 import type { TeamId } from '../config/GameConfig';
-import { TeamConfig } from '../config/GameConfig';
+import { TEAM_COLORS } from '../config/GameConfig';
 
 /**
  * Player entity with health and alive state
@@ -14,7 +14,7 @@ export class Player extends Entity {
   team: TeamId;
 
   constructor(id: string, initialNode: Node, team: TeamId, maxHealth: number = 100, isNPC: boolean = false) {
-    const color = team === 0 ? TeamConfig.Team0Color : TeamConfig.Team1Color;
+    const color = TEAM_COLORS[team] ?? TEAM_COLORS[0];
     super(id, EntityType.PLAYER, initialNode, color, 0);
     this.maxHealth = maxHealth;
     this.health = maxHealth;

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -67,12 +67,14 @@ class Model {
     const size = this.NodesInGridSize;
     const h = size * MapConfig.NodeSpacing;
 
-    // 3チームをマップ下部・中部・上部にスポーン
-    const spawnPools = [
-      this.nodeList.filter(n => n.y < h * 0.25 && this.Edges.List[n.id] !== undefined),
-      this.nodeList.filter(n => n.y >= h * 0.375 && n.y < h * 0.625 && this.Edges.List[n.id] !== undefined),
-      this.nodeList.filter(n => n.y >= h * 0.75 && this.Edges.List[n.id] !== undefined),
-    ];
+    // チーム数に応じてマップをY軸方向に均等分割してスポーンプールを生成
+    const spawnPools = Array.from({ length: LOCAL_TEAM_COUNT }, (_, team) => {
+      const yMin = (team / LOCAL_TEAM_COUNT) * h;
+      const yMax = ((team + 1) / LOCAL_TEAM_COUNT) * h;
+      return this.nodeList.filter(
+        n => n.y >= yMin && n.y < yMax && this.Edges.List[n.id] !== undefined
+      );
+    });
 
     let playerIndex = 0;
     for (let team = 0; team < LOCAL_TEAM_COUNT; team++) {

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -17,6 +17,7 @@ class Model {
   public Lines: LineSegment[] = [];
   private obstacles: ObstacleData[] = [];
   private lastSeed: string = '';
+  private losCache: Map<string, boolean> = new Map();
 
   public getLastSeed(): string {
     return this.lastSeed;
@@ -55,6 +56,7 @@ class Model {
       this.Lines = bspResult.lines;
       MapGenerator.applyObstaclesToGraph(this.Edges, this.nodeList, this.Lines);
       MapGenerator.removeNodesInsideObstacles(this.Edges, this.nodeList, this.obstacles);
+      this.buildLOSCache();
     }
   }
 
@@ -147,17 +149,35 @@ class Model {
    * @returns True if there is a clear line of sight, false if blocked by obstacles.
    */
   public hasLineOfSight(node1: Node, node2: Node): boolean {
+    const [a, b] = node1.id < node2.id
+      ? [node1.id, node2.id]
+      : [node2.id, node1.id];
+    const cached = this.losCache.get(`${a},${b}`);
+    if (cached !== undefined) return cached;
     const p1 = { x: node1.x, y: node1.y };
     const p2 = { x: node2.x, y: node2.y };
-
-    // Check if the line between nodes intersects with any obstacle segments
     for (const segment of this.Lines) {
-      if (segment.intersects(p1, p2)) {
-        return false; // Line of sight is blocked
+      if (segment.intersects(p1, p2)) return false;
+    }
+    return true;
+  }
+
+  private buildLOSCache(): void {
+    this.losCache = new Map();
+    const activeNodes = this.nodeList.filter(n => this.Edges.List[n.id] !== undefined);
+    for (let i = 0; i < activeNodes.length; i++) {
+      for (let j = i + 1; j < activeNodes.length; j++) {
+        const n1 = activeNodes[i];
+        const n2 = activeNodes[j];
+        const p1 = { x: n1.x, y: n1.y };
+        const p2 = { x: n2.x, y: n2.y };
+        let los = true;
+        for (const seg of this.Lines) {
+          if (seg.intersects(p1, p2)) { los = false; break; }
+        }
+        this.losCache.set(`${n1.id},${n2.id}`, los);
       }
     }
-
-    return true; // Clear line of sight
   }
 
   /**
@@ -295,6 +315,7 @@ class Model {
     this.obstacles = result.obstacles;
     this.Lines = result.lines;
     MapGenerator.applyObstaclesToGraph(this.Edges, this.nodeList, this.Lines);
+    this.buildLOSCache();
   }
 
   /**

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -315,6 +315,7 @@ class Model {
     this.obstacles = result.obstacles;
     this.Lines = result.lines;
     MapGenerator.applyObstaclesToGraph(this.Edges, this.nodeList, this.Lines);
+    MapGenerator.removeNodesInsideObstacles(this.Edges, this.nodeList, this.obstacles);
     this.buildLOSCache();
   }
 

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -3,7 +3,7 @@ import { Graph } from './Graph';
 import { LineSegment } from './LineSegment';
 import type { ObstacleData } from './MapGenerator';
 import { MapConfig, PlayerConfig } from '../config/GameConfig';
-import { LOCAL_PLAYER_COUNT, LOCAL_NPC_COUNT, createPlayerId } from '../config/GameConfig';
+import { LOCAL_TEAM_COUNT, LOCAL_NPC_PER_TEAM, createPlayerId } from '../config/GameConfig';
 import type { TeamId } from '../config/GameConfig';
 import { MapGenerator } from './MapGenerator';
 import { Player } from './Player';
@@ -65,32 +65,32 @@ class Model {
   public initLocalPlayers(): void {
     const usedNodeIds = new Set<number>();
     const size = this.NodesInGridSize;
-    const totalCount = LOCAL_PLAYER_COUNT + LOCAL_NPC_COUNT;
+    const h = size * MapConfig.NodeSpacing;
 
-    // Players spawn at bottom (low y), NPCs spawn at top (high y)
-    const bottomNodes = this.nodeList.filter(n => n.y < (size * MapConfig.NodeSpacing) * 0.25 && this.Edges.List[n.id] !== undefined);
-    const topNodes    = this.nodeList.filter(n => n.y >= (size * MapConfig.NodeSpacing) * 0.75 && this.Edges.List[n.id] !== undefined);
+    // 3チームをマップ下部・中部・上部にスポーン
+    const spawnPools = [
+      this.nodeList.filter(n => n.y < h * 0.25 && this.Edges.List[n.id] !== undefined),
+      this.nodeList.filter(n => n.y >= h * 0.375 && n.y < h * 0.625 && this.Edges.List[n.id] !== undefined),
+      this.nodeList.filter(n => n.y >= h * 0.75 && this.Edges.List[n.id] !== undefined),
+    ];
 
-    for (let i = 0; i < totalCount && i < this.nodeList.length; i++) {
-      const isNPC = i >= LOCAL_PLAYER_COUNT;
-      const playerId = createPlayerId(i);
-      const team: TeamId = isNPC ? 1 : 0;
-      const pool = isNPC ? topNodes : bottomNodes;
-
-      let nodeIndex: number;
-      let attempts = 0;
-      do {
-        const candidate = pool[Math.floor(Math.random() * pool.length)];
-        nodeIndex = candidate?.id ?? Math.floor(Math.random() * this.nodeList.length);
-        attempts++;
-        // fallback to full list if pool is exhausted
-        if (attempts > pool.length * 2) {
-          nodeIndex = Math.floor(Math.random() * this.nodeList.length);
-        }
-      } while (usedNodeIds.has(nodeIndex));
-
-      usedNodeIds.add(nodeIndex);
-      this.players.set(playerId, new Player(playerId, this.nodeList[nodeIndex], team, 100, isNPC));
+    let playerIndex = 0;
+    for (let team = 0; team < LOCAL_TEAM_COUNT; team++) {
+      const pool = spawnPools[team];
+      for (let i = 0; i < LOCAL_NPC_PER_TEAM; i++) {
+        const playerId = createPlayerId(playerIndex++);
+        let nodeIndex: number;
+        let attempts = 0;
+        do {
+          const candidate = pool[Math.floor(Math.random() * pool.length)];
+          nodeIndex = candidate?.id ?? Math.floor(Math.random() * this.nodeList.length);
+          if (++attempts > pool.length * 2) {
+            nodeIndex = Math.floor(Math.random() * this.nodeList.length);
+          }
+        } while (usedNodeIds.has(nodeIndex));
+        usedNodeIds.add(nodeIndex);
+        this.players.set(playerId, new Player(playerId, this.nodeList[nodeIndex], team as TeamId, 100, true));
+      }
     }
   }
 

--- a/src/network/LocalAdapter.ts
+++ b/src/network/LocalAdapter.ts
@@ -163,16 +163,17 @@ export class LocalAdapter implements INetworkAdapter {
       this.model.setPlayerRef(action.playerId, newNode);
 
       let newAngle = player.angle;
-      if (action.shotAtNodeId !== undefined) {
+      if (action.angle !== undefined) {
+        newAngle = action.angle;
+      } else if (action.shotAtNodeId !== undefined) {
         const shotNode = this.model.nodeList[action.shotAtNodeId];
         if (shotNode) {
           newAngle = this.model.getAngleBetweenNodes(newNode, shotNode);
-          player.setAngle(newAngle);
         }
       } else if (action.moveToNodeId !== fromNode.id) {
         newAngle = this.model.getAngleBetweenNodes(fromNode, newNode);
-        player.setAngle(newAngle);
       }
+      player.setAngle(newAngle);
 
       pendingResults.push({
         movingPlayerId: action.playerId,

--- a/src/network/LocalAdapter.ts
+++ b/src/network/LocalAdapter.ts
@@ -3,8 +3,6 @@ import { Node } from '../model/node';
 import { INetworkAdapter } from './INetworkAdapter';
 import { TurnAction, TurnResult, ObstaclePayload, ServerConfigPayload } from '../schema/types';
 import { PlayerConfig } from '../config/GameConfig';
-import { ENTITY_IDS } from '../config/GameConfig';
-
 /**
  * Local-play implementation of INetworkAdapter.
  * Executes all game logic in-process (no network), preserving the original behavior.
@@ -12,7 +10,7 @@ import { ENTITY_IDS } from '../config/GameConfig';
  */
 export class LocalAdapter implements INetworkAdapter {
   private model!: Model;
-  private readonly myPlayerId: string = ENTITY_IDS.PLAYER_1;
+  private readonly myPlayerId: string = '';
   private turnResultCallback?: (result: TurnResult) => void;
 
   // ---- INetworkAdapter -------------------------------------------------------

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { Model } from '../model/model';
 import { SceneManager } from './core/SceneManager';
-import { CameraConfig, PlayerConfig, RenderConfig } from '../config/GameConfig';
+import { CameraConfig, PlayerConfig, RenderConfig, AIConfig, TEAM_COLORS } from '../config/GameConfig';
 import { GameEventBus, GameEventType } from '../core/GameEventBus';
 import { PlayerAnimator } from './players/PlayerAnimator';
 import { PlayerLifecycleManager } from './players/PlayerLifecycleManager';
@@ -120,8 +120,9 @@ export class VisualizationSync {
     this.nodeVis.updateNodeColors(activePlayer);
     this.losLines.update(this.model);
 
-    // Clear heatmap when not observing team 5
-    if (activePlayer.team !== 5) {
+    if ((AIConfig.ThreatMapTeams as number[]).includes(activePlayer.team)) {
+      this.heatmap.showOnly(TEAM_COLORS[activePlayer.team]);
+    } else {
       this.heatmap.clear();
     }
   }

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -100,15 +100,17 @@ export class VisualizationSync {
   // ── Private helpers ────────────────────────────────────────────────────────
 
   private doUpdateView(): void {
-    const activePlayer = this.model.getPlayer(this.activePlayerId);
+    const activePlayer = this.model.getPlayer(this.activePlayerId)
+      ?? Array.from(this.model.players.values()).find(p => p.isAlive);
     if (!activePlayer) return;
 
-    this.updatePlayers();
+    this.updatePlayers(activePlayer);
     this.nodeVis.updateNodeColors(activePlayer);
   }
 
-  private updatePlayers(): void {
-    const activePlayer = this.model.getPlayer(this.activePlayerId);
+  private updatePlayers(activePlayer?: ReturnType<typeof this.model.getPlayer>): void {
+    activePlayer ??= this.model.getPlayer(this.activePlayerId)
+      ?? Array.from(this.model.players.values()).find(p => p.isAlive);
 
     const visibleNodeIds = new Set<number>();
     if (PlayerConfig.FogOfWarEnabled && activePlayer) {

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -9,6 +9,7 @@ import { PlayerEffects } from './players/PlayerEffects';
 import { CameraFollowController } from './cameras/CameraFollowController';
 import { NodeVisualizationManager } from './world/NodeVisualizationManager';
 import { LOSLineManager } from './world/LOSLineManager';
+import { ThreatHeatmapManager } from './world/ThreatHeatmapManager';
 import { TextBurstEffect } from './effects/TextBurstEffect';
 import { HPBarManager } from './players/HPBarManager';
 import { isPointInCone } from '../logic/ConeIntersection';
@@ -27,6 +28,7 @@ export class VisualizationSync {
   private camera:        CameraFollowController;
   private textBurstEffect: TextBurstEffect;
   private hpBarManager:  HPBarManager;
+  private heatmap:       ThreatHeatmapManager;
   private model:         Model;
 
   private activePlayerId: string;
@@ -51,6 +53,8 @@ export class VisualizationSync {
     this.losLines      = new LOSLineManager(sceneManager.getScene());
     this.camera        = new CameraFollowController(sceneManager);
     this.textBurstEffect = new TextBurstEffect(sceneManager);
+    this.heatmap       = new ThreatHeatmapManager(sceneManager);
+    this.heatmap.init(model.nodeList, model.Edges.List);
 
     // Initialize scene objects
     this.nodeVis.initializeNodes();
@@ -115,6 +119,11 @@ export class VisualizationSync {
     this.updatePlayers(activePlayer);
     this.nodeVis.updateNodeColors(activePlayer);
     this.losLines.update(this.model);
+
+    // Clear heatmap when not observing team 5
+    if (activePlayer.team !== 5) {
+      this.heatmap.clear();
+    }
   }
 
   private updatePlayers(activePlayer?: ReturnType<typeof this.model.getPlayer>): void {
@@ -234,6 +243,10 @@ export class VisualizationSync {
       if (player) {
         this.textBurstEffect.playAtGameCoords(player.node.x, player.node.y, RenderConfig.PlayerZOffset);
       }
+    });
+
+    eventBus.on(GameEventType.VIS_THREAT_MAP_UPDATED, (data: { scores: Float32Array; teamColor: number }) => {
+      this.heatmap.update(data.scores, data.teamColor);
     });
 
   }

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -8,6 +8,7 @@ import { PlayerLifecycleManager } from './players/PlayerLifecycleManager';
 import { PlayerEffects } from './players/PlayerEffects';
 import { CameraFollowController } from './cameras/CameraFollowController';
 import { NodeVisualizationManager } from './world/NodeVisualizationManager';
+import { LOSLineManager } from './world/LOSLineManager';
 import { TextBurstEffect } from './effects/TextBurstEffect';
 import { HPBarManager } from './players/HPBarManager';
 import { isPointInCone } from '../logic/ConeIntersection';
@@ -19,6 +20,7 @@ import { worldToGame } from './utils/MeshUtils';
  */
 export class VisualizationSync {
   private nodeVis:       NodeVisualizationManager;
+  private losLines:      LOSLineManager;
   private lifecycle:     PlayerLifecycleManager;
   private effects:       PlayerEffects;
   private animator:      PlayerAnimator;
@@ -46,6 +48,7 @@ export class VisualizationSync {
     this.lifecycle     = new PlayerLifecycleManager(sceneManager, this.animator, model, meshMap, eventBus, this.hpBarManager);
     this.effects       = new PlayerEffects(meshMap, this.animator, model);
     this.nodeVis       = new NodeVisualizationManager(sceneManager, model);
+    this.losLines      = new LOSLineManager(sceneManager.getScene());
     this.camera        = new CameraFollowController(sceneManager);
     this.textBurstEffect = new TextBurstEffect(sceneManager);
 
@@ -79,6 +82,11 @@ export class VisualizationSync {
     this.lifecycle.addPlayer(playerId, color);
   }
 
+  toggleLOS(): boolean {
+    this.losLines.toggle();
+    return this.losLines.isVisible();
+  }
+
   getMeshList(): THREE.Mesh[] {
     return this.nodeVis.getMeshList();
   }
@@ -106,6 +114,7 @@ export class VisualizationSync {
 
     this.updatePlayers(activePlayer);
     this.nodeVis.updateNodeColors(activePlayer);
+    this.losLines.update(this.model);
   }
 
   private updatePlayers(activePlayer?: ReturnType<typeof this.model.getPlayer>): void {

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -91,6 +91,10 @@ export class VisualizationSync {
     return this.losLines.isVisible();
   }
 
+  toggleHeatmap(): boolean {
+    return this.heatmap.toggle();
+  }
+
   getMeshList(): THREE.Mesh[] {
     return this.nodeVis.getMeshList();
   }

--- a/src/rendering/VisualizationSync.ts
+++ b/src/rendering/VisualizationSync.ts
@@ -10,6 +10,7 @@ import { CameraFollowController } from './cameras/CameraFollowController';
 import { NodeVisualizationManager } from './world/NodeVisualizationManager';
 import { LOSLineManager } from './world/LOSLineManager';
 import { ThreatHeatmapManager } from './world/ThreatHeatmapManager';
+import { ScoreNodeLabelManager } from './world/ScoreNodeLabelManager';
 import { TextBurstEffect } from './effects/TextBurstEffect';
 import { HPBarManager } from './players/HPBarManager';
 import { isPointInCone } from '../logic/ConeIntersection';
@@ -29,6 +30,7 @@ export class VisualizationSync {
   private textBurstEffect: TextBurstEffect;
   private hpBarManager:  HPBarManager;
   private heatmap:       ThreatHeatmapManager;
+  private scoreLabels:   ScoreNodeLabelManager;
   private model:         Model;
 
   private activePlayerId: string;
@@ -55,6 +57,8 @@ export class VisualizationSync {
     this.textBurstEffect = new TextBurstEffect(sceneManager);
     this.heatmap       = new ThreatHeatmapManager(sceneManager);
     this.heatmap.init(model.nodeList, model.Edges.List);
+    this.scoreLabels   = new ScoreNodeLabelManager(sceneManager);
+    this.scoreLabels.init(model.nodeList);
 
     // Initialize scene objects
     this.nodeVis.initializeNodes();
@@ -252,6 +256,14 @@ export class VisualizationSync {
 
     eventBus.on(GameEventType.VIS_THREAT_MAP_UPDATED, (data: { scores: Float32Array; teamColor: number }) => {
       this.heatmap.update(data.scores, data.teamColor);
+    });
+
+    eventBus.on(GameEventType.VIS_SCORENODE_LABELS, (data) => {
+      if (data.scores === null) {
+        this.scoreLabels.clear();
+      } else {
+        this.scoreLabels.update(data.scores);
+      }
     });
 
   }

--- a/src/rendering/cameras/FPSCameraController.ts
+++ b/src/rendering/cameras/FPSCameraController.ts
@@ -218,7 +218,6 @@ export class FPSCameraController {
       case 'Space': this.keys.space = true; e.preventDefault(); break;
       case 'ControlLeft': case 'ControlRight': this.keys.ctrl = true; break;
       case 'ShiftLeft': case 'ShiftRight': this.keys.shift = true; break;
-      case 'KeyR': this.eventBus.emit(GameEventType.NPC_ONLY_TURN); break;
     }
   }
 

--- a/src/rendering/cameras/FPSCameraController.ts
+++ b/src/rendering/cameras/FPSCameraController.ts
@@ -85,9 +85,10 @@ export class FPSCameraController {
     if (this.enabled) return;
 
     const activeId = this.getActivePlayerId();
-    const player = this.model.getPlayer(activeId);
+    const player = this.model.getPlayer(activeId)
+      ?? Array.from(this.model.players.values()).find(p => p.isAlive);
     if (!player) {
-      console.warn('[FPSCameraController] enable() called but no active player available');
+      console.warn('[FPSCameraController] enable() called but no alive player available');
       return;
     }
 
@@ -155,7 +156,8 @@ export class FPSCameraController {
 
     // アクティブプレイヤーへスナップ（パン中で取り残されたカメラを定位置に戻す）
     const activeId = this.getActivePlayerId();
-    const player = this.model.getPlayer(activeId);
+    const player = this.model.getPlayer(activeId)
+      ?? Array.from(this.model.players.values()).find(p => p.isAlive);
     if (player) {
       this.follow.snapTo(player.node.x, player.node.y, player.angle);
     }

--- a/src/rendering/core/BackgroundGrid.ts
+++ b/src/rendering/core/BackgroundGrid.ts
@@ -1,17 +1,21 @@
 import * as THREE from 'three';
-import { MapConfig, RenderConfig } from '../../config/GameConfig';
+import { RenderConfig } from '../../config/GameConfig';
+import { gameToWorld } from '../utils/MeshUtils';
+import type { Model } from '../../model/model';
 
 const GRID_USERDATA_KEY = 'isGrid';
 
 /**
- * Background grid aligned to node positions. Lines are tagged with
- * userData[isGrid] = true so that `toggle()` can find and toggle them.
+ * Draws traversable edges between adjacent nodes as background lines.
+ * Call build(model) once after the model is ready, and again after map regeneration.
  */
 export class BackgroundGrid {
-  constructor(private scene: THREE.Scene) {
-    const size = MapConfig.NodesInGridSize;
-    const spacing = MapConfig.NodeSpacing;
-    const total = (size - 1) * spacing;
+  private lines: THREE.Line[] = [];
+
+  constructor(private scene: THREE.Scene) {}
+
+  build(model: Model): void {
+    this.clear();
 
     const material = new THREE.LineBasicMaterial({
       color: RenderConfig.GridLineColor,
@@ -19,29 +23,49 @@ export class BackgroundGrid {
       opacity: RenderConfig.GridLineOpacity,
     });
 
-    for (let i = 0; i < size; i++) {
-      const x = i * spacing;
-      const vPts = [new THREE.Vector3(x, -0.5, 0), new THREE.Vector3(x, -0.5, total)];
-      const vLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(vPts), material);
-      vLine.userData[GRID_USERDATA_KEY] = true;
-      this.scene.add(vLine);
-    }
+    const drawn = new Set<string>();
 
-    for (let i = 0; i < size; i++) {
-      const z = i * spacing;
-      const hPts = [new THREE.Vector3(0, -0.5, z), new THREE.Vector3(total, -0.5, z)];
-      const hLine = new THREE.Line(new THREE.BufferGeometry().setFromPoints(hPts), material);
-      hLine.userData[GRID_USERDATA_KEY] = true;
-      this.scene.add(hLine);
+    for (const [nodeId, neighbors] of Object.entries(model.Edges.List)) {
+      const fromNode = model.nodeList[Number(nodeId)];
+      if (!fromNode) continue;
+
+      for (const neighborId of neighbors as number[]) {
+        const key = nodeId < String(neighborId)
+          ? `${nodeId}-${neighborId}`
+          : `${neighborId}-${nodeId}`;
+        if (drawn.has(key)) continue;
+        drawn.add(key);
+
+        const toNode = model.nodeList[neighborId];
+        if (!toNode) continue;
+
+        const pts = [
+          gameToWorld(fromNode.x, fromNode.y, -0.5),
+          gameToWorld(toNode.x, toNode.y, -0.5),
+        ];
+        const line = new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints(pts),
+          material,
+        );
+        line.userData[GRID_USERDATA_KEY] = true;
+        this.scene.add(line);
+        this.lines.push(line);
+      }
     }
   }
 
-  /** Toggles the visibility of all grid lines. */
+  private clear(): void {
+    for (const line of this.lines) {
+      this.scene.remove(line);
+      line.geometry.dispose();
+    }
+    this.lines = [];
+  }
+
+  /** Toggles the visibility of all edge lines. */
   toggle(): void {
-    this.scene.traverse((object) => {
-      if (object instanceof THREE.Line && object.userData[GRID_USERDATA_KEY]) {
-        object.visible = !object.visible;
-      }
-    });
+    for (const line of this.lines) {
+      line.visible = !line.visible;
+    }
   }
 }

--- a/src/rendering/core/SceneManager.ts
+++ b/src/rendering/core/SceneManager.ts
@@ -4,6 +4,7 @@ import { CameraConfig, MapConfig, RenderConfig } from '../../config/GameConfig';
 import { LightingRig } from './LightingRig';
 import { applyFogToScene, applyShadowToRenderer, setupPostProcessing } from './PostProcessing';
 import { BackgroundGrid } from './BackgroundGrid';
+import type { Model } from '../../model/model';
 
 /**
  * Owns the Three.js renderer / scene / camera and the per-frame render loop.
@@ -47,6 +48,7 @@ export class SceneManager {
     this.camera.updateProjectionMatrix();
 
     this.backgroundGrid = new BackgroundGrid(this.scene);
+    // Edge grid is built later via buildEdgeGrid(model) once the model is ready.
 
     // Origin axes helper (red=+X, green=+Y, blue=+Z) for debugging
     this.scene.add(new THREE.AxesHelper(MapConfig.NodeSpacing * 3));
@@ -122,6 +124,11 @@ export class SceneManager {
 
   getRenderer(): THREE.WebGLRenderer {
     return this.renderer;
+  }
+
+  /** Builds (or rebuilds) the edge graph lines from the model. Call after map generation. */
+  buildEdgeGrid(model: Model): void {
+    this.backgroundGrid.build(model);
   }
 
   /** Toggles the background grid visibility. */

--- a/src/rendering/players/HPBarManager.ts
+++ b/src/rendering/players/HPBarManager.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { gsap } from 'gsap';
-import { HPBarConfig } from '../../config/GameConfig';
+import { HPBarConfig, TEAM_COLORS } from '../../config/GameConfig';
+import type { TeamId } from '../../config/GameConfig';
 
 interface BarEntry {
   fg: THREE.Mesh;
@@ -27,7 +28,7 @@ interface BarEntry {
 export class HPBarManager {
   private readonly bars: Map<string, BarEntry> = new Map();
 
-  attachBar(playerId: string, group: THREE.Object3D, isNPC: boolean): void {
+  attachBar(playerId: string, group: THREE.Object3D, isNPC: boolean, team?: TeamId): void {
     if (this.bars.has(playerId)) return;
 
     const W = HPBarConfig.Width;
@@ -45,7 +46,7 @@ export class HPBarManager {
     bg.userData.fixedColor = true;
     group.add(bg);
 
-    const fgColor = isNPC ? HPBarConfig.NPCFgColor : HPBarConfig.HumanFgColor;
+    const fgColor = team !== undefined ? TEAM_COLORS[team] : (isNPC ? HPBarConfig.NPCFgColor : HPBarConfig.HumanFgColor);
     const fg = new THREE.Mesh(
       new THREE.BoxGeometry(W, H, D),
       new THREE.MeshStandardMaterial({ color: fgColor, emissive: fgColor, emissiveIntensity: 0.3 }),

--- a/src/rendering/players/PlayerLifecycleManager.ts
+++ b/src/rendering/players/PlayerLifecycleManager.ts
@@ -37,7 +37,7 @@ export class PlayerLifecycleManager {
       const obj = createVariantPlayer(player.color);
       this.sceneManager.addToScene(obj);
       this.playerMeshes.set(playerId, obj);
-      this.hpBarManager.attachBar(playerId, obj, player.isNPC);
+      this.hpBarManager.attachBar(playerId, obj, player.isNPC, player.team);
       this.animator.startIdle(playerId);
     }
   }
@@ -49,7 +49,7 @@ export class PlayerLifecycleManager {
     this.sceneManager.addToScene(obj);
     this.playerMeshes.set(playerId, obj);
     const player = this.model.getPlayer(playerId);
-    this.hpBarManager.attachBar(playerId, obj, player?.isNPC ?? false);
+    this.hpBarManager.attachBar(playerId, obj, player?.isNPC ?? false, player?.team);
     this.animator.startIdle(playerId);
   }
 

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -164,6 +164,10 @@ export class ThreeSetup {
     return this.visualizationSync.toggleLOS();
   }
 
+  toggleHeatmap(): boolean {
+    return this.visualizationSync.toggleHeatmap();
+  }
+
   /**
    * Returns all player IDs in the current game
    */

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -47,6 +47,9 @@ export class ThreeSetup {
     // Initialize game model via adapter
     const model = adapter.initializeModel();
 
+    // Build edge graph lines from the initial model state
+    this.sceneManager.buildEdgeGrid(model);
+
     // Initialize visualization synchronization
     this.visualizationSync = new VisualizationSync(
       this.sceneManager,
@@ -122,6 +125,7 @@ export class ThreeSetup {
       // them to LineSegment instances internally via MapGenerator.importObstacles().
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.gameController.importObstacles(obstacles as any);
+      this.sceneManager.buildEdgeGrid(model);
     });
 
     // Start render loop

--- a/src/rendering/threeSetup.ts
+++ b/src/rendering/threeSetup.ts
@@ -160,6 +160,10 @@ export class ThreeSetup {
     this.sceneManager.toggleGrid();
   }
 
+  toggleLOS(): boolean {
+    return this.visualizationSync.toggleLOS();
+  }
+
   /**
    * Returns all player IDs in the current game
    */

--- a/src/rendering/world/LOSLineManager.ts
+++ b/src/rendering/world/LOSLineManager.ts
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+import { PlayerConfig, RenderConfig } from '../../config/GameConfig';
+import { gameToWorld } from '../utils/MeshUtils';
+import type { Model } from '../../model/model';
+
+/**
+ * Draws line-of-sight rays from every alive player to all nodes visible
+ * within their current FOV. Rebuilt each time update() is called.
+ */
+export class LOSLineManager {
+  private lines: THREE.Line[] = [];
+  private material: THREE.LineBasicMaterial;
+  private visible = true;
+
+  constructor(private scene: THREE.Scene) {
+    this.material = new THREE.LineBasicMaterial({
+      color: RenderConfig.LOSLineColor,
+      transparent: true,
+      opacity: RenderConfig.LOSLineOpacity,
+    });
+  }
+
+  update(model: Model): void {
+    this.clear();
+    if (!this.visible) return;
+
+    for (const player of model.players.values()) {
+      if (!player.isAlive) continue;
+
+      const visibleNodes = model.getVisibleNodesAtAngle(
+        player.node,
+        player.angle,
+        PlayerConfig.MaxViewDistance,
+      );
+
+      const from = gameToWorld(player.node.x, player.node.y, 0);
+
+      for (const node of visibleNodes) {
+        const to = gameToWorld(node.x, node.y, 0);
+        const line = new THREE.Line(
+          new THREE.BufferGeometry().setFromPoints([from, to]),
+          this.material,
+        );
+        this.scene.add(line);
+        this.lines.push(line);
+      }
+    }
+  }
+
+  toggle(): void {
+    this.visible = !this.visible;
+    if (!this.visible) this.clear();
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+
+  private clear(): void {
+    for (const line of this.lines) {
+      this.scene.remove(line);
+      line.geometry.dispose();
+    }
+    this.lines = [];
+  }
+}

--- a/src/rendering/world/LOSLineManager.ts
+++ b/src/rendering/world/LOSLineManager.ts
@@ -10,7 +10,7 @@ import type { Model } from '../../model/model';
 export class LOSLineManager {
   private lines: THREE.Line[] = [];
   private material: THREE.LineBasicMaterial;
-  private visible = true;
+  private visible = false;
 
   constructor(private scene: THREE.Scene) {
     this.material = new THREE.LineBasicMaterial({

--- a/src/rendering/world/ScoreNodeLabelManager.ts
+++ b/src/rendering/world/ScoreNodeLabelManager.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { SceneManager } from '../core/SceneManager';
+import { gameToWorld } from '../utils/MeshUtils';
+import { Node } from '../../model/node';
+import { ScoreLabelConfig } from '../../config/GameConfig';
+
+export class ScoreNodeLabelManager {
+  private sprites: Map<number, THREE.Sprite> = new Map();
+  private nodeList: Node[] = [];
+
+  constructor(private sceneManager: SceneManager) {}
+
+  init(nodeList: Node[]): void {
+    this.nodeList = nodeList;
+  }
+
+  update(scores: Map<number, number>): void {
+    this.clear();
+    for (const [nodeId, score] of scores) {
+      const node = this.nodeList[nodeId];
+      if (!node) continue;
+      const sprite = this.createLabel(score);
+      const pos = gameToWorld(node.x, node.y, ScoreLabelConfig.Height);
+      sprite.position.copy(pos);
+      this.sceneManager.addToScene(sprite);
+      this.sprites.set(nodeId, sprite);
+    }
+  }
+
+  clear(): void {
+    for (const sprite of this.sprites.values()) {
+      this.sceneManager.removeFromScene(sprite);
+      (sprite.material as THREE.SpriteMaterial).map?.dispose();
+      (sprite.material as THREE.SpriteMaterial).dispose();
+    }
+    this.sprites.clear();
+  }
+
+  private createLabel(score: number): THREE.Sprite {
+    const cfg = ScoreLabelConfig;
+    const size = cfg.CanvasSize;
+    const canvas = document.createElement('canvas');
+    canvas.width  = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d')!;
+
+    const color = score > 5 ? cfg.ColorHigh : score < -5 ? cfg.ColorLow : cfg.ColorMid;
+    const fontSize = Math.floor(size * cfg.FontSizeRatio);
+    ctx.font         = `bold ${fontSize}px monospace`;
+    ctx.textAlign    = 'center';
+    ctx.textBaseline = 'middle';
+
+    const text = String(Math.round(score));
+    const textWidth = ctx.measureText(text).width;
+    const pad = size * cfg.BgPaddingRatio;
+    const bgX = size / 2 - textWidth / 2 - pad;
+    const bgY = size / 2 - fontSize / 2 - pad;
+    const bgW = textWidth + pad * 2;
+    const bgH = fontSize + pad * 2;
+
+    ctx.fillStyle = cfg.BgColor;
+    ctx.beginPath();
+    ctx.roundRect(bgX, bgY, bgW, bgH, pad);
+    ctx.fill();
+
+    ctx.fillStyle = color;
+    ctx.fillText(text, size / 2, size / 2);
+
+    const texture  = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({
+      map: texture, transparent: true, depthTest: false,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.setScalar(cfg.SpriteWorldSize);
+    return sprite;
+  }
+}

--- a/src/rendering/world/ThreatHeatmapManager.ts
+++ b/src/rendering/world/ThreatHeatmapManager.ts
@@ -19,6 +19,7 @@ export class ThreatHeatmapManager {
   private layers: Map<number, Map<number, THREE.Mesh>> = new Map();
   private nodeList: Node[] = [];
   private edgeList: { [nodeId: number]: number[] } = {};
+  private visible = true;
 
   constructor(private sceneManager: SceneManager) {}
 
@@ -27,7 +28,18 @@ export class ThreatHeatmapManager {
     this.edgeList = edgeList;
   }
 
+  toggle(): boolean {
+    this.visible = !this.visible;
+    if (!this.visible) this.clear();
+    return this.visible;
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+
   update(scores: Float32Array, teamColor: number): void {
+    if (!this.visible) return;
     if (!this.layers.has(teamColor)) {
       this._createLayer(teamColor);
     }
@@ -49,10 +61,11 @@ export class ThreatHeatmapManager {
 
   /** Show only the layer for the given teamColor; hide all others. */
   showOnly(teamColor: number): void {
+    if (!this.visible) return;
     for (const [color, layer] of this.layers) {
-      const visible = color === teamColor;
+      const isActive = color === teamColor;
       for (const mesh of layer.values()) {
-        if (!visible) (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
+        if (!isActive) (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
       }
     }
   }

--- a/src/rendering/world/ThreatHeatmapManager.ts
+++ b/src/rendering/world/ThreatHeatmapManager.ts
@@ -1,0 +1,62 @@
+import * as THREE from 'three';
+import { Node } from '../../model/node';
+import { SceneManager } from '../core/SceneManager';
+import { gameToWorld } from '../utils/MeshUtils';
+import { NodeConfig } from '../../config/GameConfig';
+
+const HEATMAP_HEIGHT = 1.5;
+const HEATMAP_MAX_OPACITY = 0.6;
+const PLANE_SIZE_FACTOR = 2.0;
+
+/**
+ * Renders a ThreatMap as a per-node semi-transparent overlay in the 3D scene.
+ * Each node gets a horizontal PlaneGeometry positioned above it.
+ * opacity = score * HEATMAP_MAX_OPACITY; color = team color.
+ */
+export class ThreatHeatmapManager {
+  /** Indexed by node.id; undefined for nodes excluded from the graph (inside obstacles). */
+  private planes: Map<number, THREE.Mesh> = new Map();
+
+  constructor(private sceneManager: SceneManager) {}
+
+  init(nodeList: Node[], edgeList: { [nodeId: number]: number[] }): void {
+    const geo = new THREE.PlaneGeometry(
+      NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
+      NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
+    );
+
+    for (const node of nodeList) {
+      if (!edgeList[node.id]) continue;
+
+      const mat = new THREE.MeshBasicMaterial({
+        color: 0xffffff,
+        transparent: true,
+        depthTest: false,
+        opacity: 0,
+        side: THREE.DoubleSide,
+      });
+
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.rotation.x = -Math.PI / 2;
+      mesh.position.copy(gameToWorld(node.x, node.y, HEATMAP_HEIGHT));
+
+      this.sceneManager.addToScene(mesh);
+      this.planes.set(node.id, mesh);
+    }
+  }
+
+  update(scores: Float32Array, teamColor: number): void {
+    for (const [nodeId, mesh] of this.planes) {
+      const score = scores[nodeId] ?? 0;
+      const mat = mesh.material as THREE.MeshBasicMaterial;
+      mat.color.setHex(teamColor);
+      mat.opacity = score * HEATMAP_MAX_OPACITY;
+    }
+  }
+
+  clear(): void {
+    for (const mesh of this.planes.values()) {
+      (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
+    }
+  }
+}

--- a/src/rendering/world/ThreatHeatmapManager.ts
+++ b/src/rendering/world/ThreatHeatmapManager.ts
@@ -7,29 +7,71 @@ import { NodeConfig } from '../../config/GameConfig';
 const HEATMAP_HEIGHT = 1.5;
 const HEATMAP_MAX_OPACITY = 0.6;
 const PLANE_SIZE_FACTOR = 2.0;
+const LAYER_HEIGHT_STEP = 0.05;
 
 /**
- * Renders a ThreatMap as a per-node semi-transparent overlay in the 3D scene.
- * Each node gets a horizontal PlaneGeometry positioned above it.
+ * Renders ThreatMaps as per-node semi-transparent overlays in the 3D scene.
+ * Each team gets its own layer of PlaneGeometry meshes, created lazily on first update.
  * opacity = score * HEATMAP_MAX_OPACITY; color = team color.
  */
 export class ThreatHeatmapManager {
-  /** Indexed by node.id; undefined for nodes excluded from the graph (inside obstacles). */
-  private planes: Map<number, THREE.Mesh> = new Map();
+  /** teamColor → (nodeId → Mesh) */
+  private layers: Map<number, Map<number, THREE.Mesh>> = new Map();
+  private nodeList: Node[] = [];
+  private edgeList: { [nodeId: number]: number[] } = {};
 
   constructor(private sceneManager: SceneManager) {}
 
   init(nodeList: Node[], edgeList: { [nodeId: number]: number[] }): void {
+    this.nodeList = nodeList;
+    this.edgeList = edgeList;
+  }
+
+  update(scores: Float32Array, teamColor: number): void {
+    if (!this.layers.has(teamColor)) {
+      this._createLayer(teamColor);
+    }
+    const layer = this.layers.get(teamColor)!;
+    for (const [nodeId, mesh] of layer) {
+      const score = scores[nodeId] ?? 0;
+      (mesh.material as THREE.MeshBasicMaterial).opacity = score * HEATMAP_MAX_OPACITY;
+    }
+  }
+
+  /** Hide all layers. */
+  clear(): void {
+    for (const layer of this.layers.values()) {
+      for (const mesh of layer.values()) {
+        (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
+      }
+    }
+  }
+
+  /** Show only the layer for the given teamColor; hide all others. */
+  showOnly(teamColor: number): void {
+    for (const [color, layer] of this.layers) {
+      const visible = color === teamColor;
+      for (const mesh of layer.values()) {
+        if (!visible) (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
+      }
+    }
+  }
+
+  private _createLayer(teamColor: number): void {
+    const layerIndex = this.layers.size;
+    const height = HEATMAP_HEIGHT + layerIndex * LAYER_HEIGHT_STEP;
     const geo = new THREE.PlaneGeometry(
       NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
       NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
     );
 
-    for (const node of nodeList) {
-      if (!edgeList[node.id]) continue;
+    const planes = new Map<number, THREE.Mesh>();
+
+    for (const node of this.nodeList) {
+      if (!this.edgeList[node.id]) continue;
 
       const mat = new THREE.MeshBasicMaterial({
-        color: 0xffffff,
+        color: teamColor,
         transparent: true,
         depthTest: false,
         opacity: 0,
@@ -38,25 +80,12 @@ export class ThreatHeatmapManager {
 
       const mesh = new THREE.Mesh(geo, mat);
       mesh.rotation.x = -Math.PI / 2;
-      mesh.position.copy(gameToWorld(node.x, node.y, HEATMAP_HEIGHT));
+      mesh.position.copy(gameToWorld(node.x, node.y, height));
 
       this.sceneManager.addToScene(mesh);
-      this.planes.set(node.id, mesh);
+      planes.set(node.id, mesh);
     }
-  }
 
-  update(scores: Float32Array, teamColor: number): void {
-    for (const [nodeId, mesh] of this.planes) {
-      const score = scores[nodeId] ?? 0;
-      const mat = mesh.material as THREE.MeshBasicMaterial;
-      mat.color.setHex(teamColor);
-      mat.opacity = score * HEATMAP_MAX_OPACITY;
-    }
-  }
-
-  clear(): void {
-    for (const mesh of this.planes.values()) {
-      (mesh.material as THREE.MeshBasicMaterial).opacity = 0;
-    }
+    this.layers.set(teamColor, planes);
   }
 }

--- a/src/rendering/world/ThreatHeatmapManager.ts
+++ b/src/rendering/world/ThreatHeatmapManager.ts
@@ -20,6 +20,7 @@ export class ThreatHeatmapManager {
   private nodeList: Node[] = [];
   private edgeList: { [nodeId: number]: number[] } = {};
   private visible = true;
+  private sharedGeo: THREE.PlaneGeometry | null = null;
 
   constructor(private sceneManager: SceneManager) {}
 
@@ -73,10 +74,13 @@ export class ThreatHeatmapManager {
   private _createLayer(teamColor: number): void {
     const layerIndex = this.layers.size;
     const height = HEATMAP_HEIGHT + layerIndex * LAYER_HEIGHT_STEP;
-    const geo = new THREE.PlaneGeometry(
-      NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
-      NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
-    );
+    if (!this.sharedGeo) {
+      this.sharedGeo = new THREE.PlaneGeometry(
+        NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
+        NodeConfig.CircleSize * PLANE_SIZE_FACTOR,
+      );
+    }
+    const geo = this.sharedGeo;
 
     const planes = new Map<number, THREE.Mesh>();
 

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -8,6 +8,7 @@ export interface TurnAction {
   playerId: string;
   moveToNodeId: number;
   shotAtNodeId: number | undefined;
+  angle?: number;
 }
 
 /** Result returned after a turn is executed */

--- a/src/ui/GRF_main.tsx
+++ b/src/ui/GRF_main.tsx
@@ -56,8 +56,7 @@ const GRF_main = () => {
   }, []);
 
   const handleOffline = React.useCallback(() => {
-    const setup = startGame(new LocalAdapter());
-    setup?.enableFps();
+    startGame(new LocalAdapter());
   }, [startGame]);
 
   const handleOnline = React.useCallback(async (serverUrl: string) => {

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -16,6 +16,7 @@ interface PlayerHUDState {
   isConfirmed: boolean;
   isDead: boolean;
   team: TeamId;
+  isNPC: boolean;
 }
 
 const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
@@ -73,13 +74,15 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
   const [fogEnabled, setFogEnabled] = React.useState(PlayerConfig.FogOfWarEnabled);
   const [playerStates, setPlayerStates] = React.useState<PlayerHUDState[]>([]);
   const [confirmedCount, setConfirmedCount] = React.useState(0);
+  const [autoLoop, setAutoLoop] = React.useState(true);
+  const [inputLocked, setInputLocked] = React.useState(false);
 
   React.useEffect(() => {
     if (!threeSetup) return;
     const model = threeSetup.getModel();
     const states: PlayerHUDState[] = [];
     for (const [id, p] of model.players) {
-      states.push({ id, hp: p.health, maxHp: p.maxHealth, isActive: false, isConfirmed: false, isDead: !p.isAlive, team: p.team });
+      states.push({ id, hp: p.health, maxHp: p.maxHealth, isActive: false, isConfirmed: false, isDead: !p.isAlive, team: p.team, isNPC: p.isNPC });
     }
     if (states.length > 0) states[0].isActive = true;
     setPlayerStates(states);
@@ -101,13 +104,6 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
       });
     };
 
-    const onInputLocked = (data: { locked: boolean }) => {
-      if (!data.locked) {
-        setPlayerStates(prev => prev.map(s => ({ ...s, isConfirmed: false, isActive: false })));
-        setConfirmedCount(0);
-      }
-    };
-
     const onHit = (data: { targetId: string }) => {
       if (!threeSetup) return;
       const model = threeSetup.getModel();
@@ -124,18 +120,29 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
       ));
     };
 
+    const onAutoLoopChanged = (data: { enabled: boolean }) => setAutoLoop(data.enabled);
+    const onInputLockedChange = (data: { locked: boolean }) => {
+      setInputLocked(data.locked);
+      if (!data.locked) {
+        setPlayerStates(prev => prev.map(s => ({ ...s, isConfirmed: false, isActive: false })));
+        setConfirmedCount(0);
+      }
+    };
+
     gameEventBus.on(GameEventType.VIS_SET_ACTIVE_PLAYER, onActivePlayer);
     gameEventBus.on(GameEventType.PLAYER_ACTION_CONFIRMED, onActionConfirmed);
-    gameEventBus.on(GameEventType.INPUT_LOCKED, onInputLocked);
+    gameEventBus.on(GameEventType.INPUT_LOCKED, onInputLockedChange);
     gameEventBus.on(GameEventType.HIT_DETECTED, onHit);
     gameEventBus.on(GameEventType.VIS_HIDE_PLAYER, onHidePlayer);
+    gameEventBus.on(GameEventType.SPECTATOR_AUTO_LOOP_CHANGED, onAutoLoopChanged);
 
     return () => {
       gameEventBus.off(GameEventType.VIS_SET_ACTIVE_PLAYER, onActivePlayer);
       gameEventBus.off(GameEventType.PLAYER_ACTION_CONFIRMED, onActionConfirmed);
-      gameEventBus.off(GameEventType.INPUT_LOCKED, onInputLocked);
+      gameEventBus.off(GameEventType.INPUT_LOCKED, onInputLockedChange);
       gameEventBus.off(GameEventType.HIT_DETECTED, onHit);
       gameEventBus.off(GameEventType.VIS_HIDE_PLAYER, onHidePlayer);
+      gameEventBus.off(GameEventType.SPECTATOR_AUTO_LOOP_CHANGED, onAutoLoopChanged);
     };
   }, [threeSetup]);
 
@@ -151,6 +158,17 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     gameEventBus.emit(GameEventType.VIS_UPDATE_VIEW);
   };
 
+  const handleToggleAutoLoop = () => {
+    gameEventBus.emit(GameEventType.SPECTATOR_SET_AUTO_LOOP, { enabled: !autoLoop });
+  };
+
+  const handleNextRound = () => {
+    if (!inputLocked) {
+      gameEventBus.emit(GameEventType.NPC_ONLY_TURN);
+    }
+  };
+
+  const isSpectatorMode = playerStates.length > 0 && playerStates.every(s => s.isNPC);
   const aliveCount = playerStates.filter(s => !s.isDead).length;
 
   const containerStyle: React.CSSProperties = {
@@ -189,6 +207,25 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
       >
         霧: {fogEnabled ? 'ON' : 'OFF'}
       </button>
+      {isSpectatorMode && (
+        <>
+          <button
+            onClick={handleToggleAutoLoop}
+            style={{ ...baseButtonStyle, backgroundColor: autoLoop ? '#8e44ad' : '#444444' }}
+          >
+            {autoLoop ? '自動実行中' : '手動モード'}
+          </button>
+          {!autoLoop && (
+            <button
+              onClick={handleNextRound}
+              disabled={inputLocked}
+              style={{ ...baseButtonStyle, backgroundColor: inputLocked ? '#555' : '#27ae60', opacity: inputLocked ? 0.5 : 1, cursor: inputLocked ? 'not-allowed' : 'pointer' }}
+            >
+              次のラウンド ▶
+            </button>
+          )}
+        </>
+      )}
       {playerStates.length > 0 && (
         <>
           <div style={{

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -19,7 +19,7 @@ interface PlayerHUDState {
   isNPC: boolean;
 }
 
-const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
+const PlayerCard: React.FC<{ state: PlayerHUDState; onSelect?: () => void }> = ({ state, onSelect }) => {
   const hpPct = Math.max(0, state.hp / state.maxHp);
   const hpColor = hpPct > 0.5 ? '#27ae60' : hpPct > 0.25 ? '#e67e22' : '#c0392b';
 
@@ -36,17 +36,20 @@ const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
   const teamColor = '#' + TEAM_COLORS[state.team].toString(16).padStart(6, '0');
 
   return (
-    <div style={{
-      padding: '6px 10px',
-      borderRadius: '5px',
-      background: bgColor,
-      opacity: state.isDead ? 0.45 : 1,
-      minWidth: '90px',
-      color: 'white',
-      fontSize: '12px',
-      fontFamily: 'monospace',
-      border: `2px solid ${teamColor}`,
-    }}>
+    <div
+      onClick={onSelect}
+      style={{
+        padding: '6px 10px',
+        borderRadius: '5px',
+        background: bgColor,
+        opacity: state.isDead ? 0.45 : 1,
+        minWidth: '90px',
+        color: 'white',
+        fontSize: '12px',
+        fontFamily: 'monospace',
+        border: `2px solid ${teamColor}`,
+        cursor: onSelect ? 'pointer' : 'default',
+      }}>
       <div style={{ fontWeight: 'bold', marginBottom: '3px' }}>{state.id}</div>
       <div style={{
         height: '6px',
@@ -168,6 +171,10 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     }
   };
 
+  const handleSelectPlayer = (playerId: string) => {
+    gameEventBus.emit(GameEventType.SPECTATOR_SELECT_PLAYER, { playerId });
+  };
+
   const isSpectatorMode = playerStates.length > 0 && playerStates.every(s => s.isNPC);
   const aliveCount = playerStates.filter(s => !s.isDead).length;
 
@@ -250,7 +257,13 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
             scrollbarWidth: 'thin',
             scrollbarColor: '#555 transparent',
           }}>
-            {playerStates.map(s => <PlayerCard key={s.id} state={s} />)}
+            {playerStates.map(s => (
+              <PlayerCard
+                key={s.id}
+                state={s}
+                onSelect={isSpectatorMode && !s.isDead ? () => handleSelectPlayer(s.id) : undefined}
+              />
+            ))}
           </div>
         </>
       )}

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -75,6 +75,7 @@ const PlayerCard: React.FC<{ state: PlayerHUDState; onSelect?: () => void }> = (
 const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
   const [gridVisible, setGridVisible] = React.useState(true);
   const [losVisible, setLosVisible] = React.useState(true);
+  const [heatmapVisible, setHeatmapVisible] = React.useState(true);
   const [fogEnabled, setFogEnabled] = React.useState(PlayerConfig.FogOfWarEnabled);
   const [playerStates, setPlayerStates] = React.useState<PlayerHUDState[]>([]);
   const [confirmedCount, setConfirmedCount] = React.useState(0);
@@ -162,6 +163,12 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     setLosVisible(next);
   };
 
+  const handleToggleHeatmap = () => {
+    if (!threeSetup) return;
+    const next = threeSetup.toggleHeatmap();
+    setHeatmapVisible(next);
+  };
+
   const handleToggleFog = () => {
     PlayerConfig.FogOfWarEnabled = !PlayerConfig.FogOfWarEnabled;
     setFogEnabled(PlayerConfig.FogOfWarEnabled);
@@ -227,6 +234,13 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
         aria-label={`霧: ${fogEnabled ? 'ON' : 'OFF'}`}
       >
         霧: {fogEnabled ? 'ON' : 'OFF'}
+      </button>
+      <button
+        onClick={handleToggleHeatmap}
+        style={{ ...baseButtonStyle, backgroundColor: heatmapVisible ? '#8e44ad' : '#444444' }}
+        aria-label={`脅威図: ${heatmapVisible ? 'ON' : 'OFF'}`}
+      >
+        脅威図: {heatmapVisible ? 'ON' : 'OFF'}
       </button>
       {isSpectatorMode && (
         <>

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import type { ThreeSetup } from '../rendering/threeSetup';
 import { gameEventBus, GameEventType } from '../core/GameEventBus';
-import { PlayerConfig } from '../config/GameConfig';
+import { PlayerConfig, TEAM_COLORS } from '../config/GameConfig';
+import type { TeamId } from '../config/GameConfig';
 
 interface GameHUDProps {
   threeSetup: ThreeSetup | null;
@@ -14,6 +15,7 @@ interface PlayerHUDState {
   isActive: boolean;
   isConfirmed: boolean;
   isDead: boolean;
+  team: TeamId;
 }
 
 const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
@@ -30,6 +32,8 @@ const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
     : state.isConfirmed ? 'rgba(20,100,50,0.85)'
     : 'rgba(40,40,60,0.7)';
 
+  const teamColor = '#' + TEAM_COLORS[state.team].toString(16).padStart(6, '0');
+
   return (
     <div style={{
       padding: '6px 10px',
@@ -40,6 +44,7 @@ const PlayerCard: React.FC<{ state: PlayerHUDState }> = ({ state }) => {
       color: 'white',
       fontSize: '12px',
       fontFamily: 'monospace',
+      border: `2px solid ${teamColor}`,
     }}>
       <div style={{ fontWeight: 'bold', marginBottom: '3px' }}>{state.id}</div>
       <div style={{
@@ -74,7 +79,7 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     const model = threeSetup.getModel();
     const states: PlayerHUDState[] = [];
     for (const [id, p] of model.players) {
-      states.push({ id, hp: p.health, maxHp: p.maxHealth, isActive: false, isConfirmed: false, isDead: !p.isAlive });
+      states.push({ id, hp: p.health, maxHp: p.maxHealth, isActive: false, isConfirmed: false, isDead: !p.isAlive, team: p.team });
     }
     if (states.length > 0) states[0].isActive = true;
     setPlayerStates(states);

--- a/src/ui/GameHUD.tsx
+++ b/src/ui/GameHUD.tsx
@@ -74,6 +74,7 @@ const PlayerCard: React.FC<{ state: PlayerHUDState; onSelect?: () => void }> = (
 
 const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
   const [gridVisible, setGridVisible] = React.useState(true);
+  const [losVisible, setLosVisible] = React.useState(true);
   const [fogEnabled, setFogEnabled] = React.useState(PlayerConfig.FogOfWarEnabled);
   const [playerStates, setPlayerStates] = React.useState<PlayerHUDState[]>([]);
   const [confirmedCount, setConfirmedCount] = React.useState(0);
@@ -155,6 +156,12 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
     setGridVisible(v => !v);
   };
 
+  const handleToggleLOS = () => {
+    if (!threeSetup) return;
+    const next = threeSetup.toggleLOS();
+    setLosVisible(next);
+  };
+
   const handleToggleFog = () => {
     PlayerConfig.FogOfWarEnabled = !PlayerConfig.FogOfWarEnabled;
     setFogEnabled(PlayerConfig.FogOfWarEnabled);
@@ -206,6 +213,13 @@ const GameHUD: React.FC<GameHUDProps> = ({ threeSetup }) => {
         aria-label={`グリッド: ${gridVisible ? 'ON' : 'OFF'}`}
       >
         グリッド: {gridVisible ? 'ON' : 'OFF'}
+      </button>
+      <button
+        onClick={handleToggleLOS}
+        style={{ ...baseButtonStyle, backgroundColor: losVisible ? '#e67e22' : '#444444' }}
+        aria-label={`視線: ${losVisible ? 'ON' : 'OFF'}`}
+      >
+        視線: {losVisible ? 'ON' : 'OFF'}
       </button>
       <button
         onClick={handleToggleFog}


### PR DESCRIPTION
## 概要

3チーム/6チーム NPC 観戦モードと、NPC AI の意思決定システム（ThreatMap）を追加するブランチ。main から25コミット先行。

## 主な変更

### NPC AI / ThreatMap
- チーム別敵プレゼンス推定システム **ThreatMap** を追加（累積型 BFS 拡散方式）
- `scoreNode` を ThreatMap ベースに書き換え、全知性（全知 LOS）を除去
- NPC に目的地システム（`NPCGoalManager` / `NPCGoalState`）を追加し盤面膠着を解消
- NPC の向きを「視野内最近敵優先・見えなければ前回維持」に変更
- NPC AI 仕様書 `document/npc-ai.md` を追加

### 観戦モード
- 緑チーム追加・3チーム NPC 観戦モードを実装
- HUD の PlayerCard クリックによる NPC 選択
- 手動1ラウンド進行 UI（FPS モード中 R キー対応）
- 6チーム・10人・大型マップ対応

### パフォーマンス
- ノードペア LOS キャッシュを導入し `hasLineOfSight` を O(1) 化
- ThreatMap の BFS / Float32Array / PlaneGeometry アロケーション削減
- ThreatMap の VIS emit をアクティブチームのみに絞り込み
- ShadowMap と Bloom を無効化してフレームレート改善

### 可視化
- ThreatMap ヒートマップの3Dシーン描画と表示/非表示ボタン
- 視線(LOS)ライン表示の切り替え（デフォルト OFF）
- NPC 選択時の scoreNode 評価スコアをノード上に数値表示
- 背景グリッドを移動可能エッジ描画に変更

## テスト

- [ ] `npm run build` / `npm run lint`
- [ ] オフライン観戦モードでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
